### PR TITLE
Aggregate extraction errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5570,7 +5570,7 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#523422fce75f217ca63e18c71fb7b5e5c73a24e8",
+      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#9a9ac1c09b46cfa9b096c65a6c386a30390822d1",
       "from": "git+https://github.com/mcode/mcode-extraction-framework.git",
       "requires": {
         "axios": "^0.19.0",

--- a/src/ICARECSVClient.js
+++ b/src/ICARECSVClient.js
@@ -22,8 +22,8 @@ class ICARECSVClient extends BaseClient {
   }
 
   async get(args) {
-    const bundle = await super.get(args);
-    return generateNewMessageBundle(bundle);
+    const { bundle, extractionErrors } = await super.get(args);
+    return { bundle: generateNewMessageBundle(bundle), extractionErrors };
   }
 }
 

--- a/test/ICARECSVClient.test.js
+++ b/test/ICARECSVClient.test.js
@@ -33,30 +33,30 @@ condExtractorGetSpy
 
 describe('ICAREClient', () => {
   test('get returns a valid message bundle', async () => {
-    const data = await icareClient.get({
+    const { bundle } = await icareClient.get({
       mrn: MOCK_PATIENT_MRN,
       fromDate: MOCK_FROM_DATE,
       toDate: MOCK_TO_DATE,
     });
-    expect(data.resourceType).toEqual('Bundle');
-    expect(data.type).toEqual('message');
-    expect(data.timestamp).toEqual(moment().format('YYYY-MM-DDThh:mm:ssZ'));
-    expect(data.entry).toBeDefined();
-    expect(data.entry[0].resource.resourceType).toEqual('MessageHeader');
-    expect(data.entry[1].resource.resourceType).toEqual('Bundle');
-    expect(data.entry[1].resource.type).toEqual('collection');
+    expect(bundle.resourceType).toEqual('Bundle');
+    expect(bundle.type).toEqual('message');
+    expect(bundle.timestamp).toEqual(moment().format('YYYY-MM-DDThh:mm:ssZ'));
+    expect(bundle.entry).toBeDefined();
+    expect(bundle.entry[0].resource.resourceType).toEqual('MessageHeader');
+    expect(bundle.entry[1].resource.resourceType).toEqual('Bundle');
+    expect(bundle.entry[1].resource.type).toEqual('collection');
     // Bundle-length should be 2 - 1 header and 1 collection resource
-    expect(data.entry.length).toEqual(2);
+    expect(bundle.entry.length).toEqual(2);
     // messageHeader id should match messageHeader fullURLId
-    expect(data.entry[0].resource.id).toEqual(data.entry[0].fullUrl.split(':')[2]);
+    expect(bundle.entry[0].resource.id).toEqual(bundle.entry[0].fullUrl.split(':')[2]);
     // messageBody id should match messageBody fullURLId
-    expect(data.entry[1].resource.id).toEqual(data.entry[1].fullUrl.split(':')[2]);
+    expect(bundle.entry[1].resource.id).toEqual(bundle.entry[1].fullUrl.split(':')[2]);
     // messageBody id should match messageHeader focus
-    expect(data.entry[1].resource.id).toEqual(data.entry[0].resource.focus[0].reference.split(':')[2]);
+    expect(bundle.entry[1].resource.id).toEqual(bundle.entry[0].resource.focus[0].reference.split(':')[2]);
   });
 
   test('get returns a bundle containing all our example entries', async () => {
-    const data = await icareClient.get({
+    const { bundle } = await icareClient.get({
       mrn: MOCK_PATIENT_MRN,
       fromDate: MOCK_FROM_DATE,
       toDate: MOCK_TO_DATE,
@@ -64,7 +64,7 @@ describe('ICAREClient', () => {
     // Collection bundle has all expected entries, and no more than that
     const resourceTotal = exampleCondition.entry.length;
 
-    expect(data.entry[1].resource.entry.length).toEqual(resourceTotal);
-    expect(data.entry[1].resource.entry).toEqual(expect.arrayContaining([exampleCondition.entry[0]]));
+    expect(bundle.entry[1].resource.entry.length).toEqual(resourceTotal);
+    expect(bundle.entry[1].resource.entry).toEqual(expect.arrayContaining([exampleCondition.entry[0]]));
   });
 });

--- a/test/helpers/cliUtils.test.js
+++ b/test/helpers/cliUtils.test.js
@@ -125,7 +125,7 @@ describe('cliUtils', () => {
     it('should log a successful run when icare client successful returns a message bundle', async () => {
       mockIcareClient.get.mockClear();
       mockRunLogger.addRun.mockClear();
-      mockIcareClient.get.mockReturnValue(testBundle);
+      mockIcareClient.get.mockReturnValue({ bundle: testBundle, extractionErrors: [] });
       mockMessagingClient.canSendMessage.mockReturnValue(true);
       await expect(extractDataForPatients(true, testConfig, testPatientIds, mockIcareClient, mockMessagingClient, mockRunLogger, testFromDate, testToDate)).resolves.not.toThrowError();
       expect(mockIcareClient.get).toHaveBeenCalledTimes(testPatientIds.length);


### PR DESCRIPTION
- Updated `ICARECSVClient` to return bundle and extraction errors from `BaseClient`.
- Updated `extractDataForPatients` to aggregate and return all errors from csv client and messaging client.
- cli logs all errors for each patient at the end.
    -  Did we want to do anything else with the errors?
- Make sure to pull `BaseClient` changes from this PR(https://github.com/mcode/mcode-extraction-framework/pull/31)
# Testing guidance
- Ensure all tests pass
- Ensure client can run and errors are logged at end of extraction with debug logging
- To generate errors, remove required fields from csvs.