### PR TITLE
Email for error notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Each extractor uses various methods to gather data and format that data into [mC
 ## Email Notification
 
 The ICARE Extraction Client supports sending an email using the SMTP protocol when there are errors during data extraction.
+The connection to the SMTP server is considered authenticated from the start. Currently, there is no support for providing authentication information separately through configuration.
 In order to send an email, users must specify the hostname or IP address of an SMTP server to connect to, the port to connect to, the email addresses to send the email to, and the email address to send from. These fields must be specified in the `notificationInfo` object in the configuration file.
 An example of this object can be found in [`config/icare-csv-config.example.json`](config/icare-csv-config.example.json).
 

--- a/README.md
+++ b/README.md
@@ -80,10 +80,17 @@ Each extractor uses various methods to gather data and format that data into [mC
 
 The ICARE Extraction Client supports sending an email using the SMTP protocol when there are errors during data extraction.
 The connection to the SMTP server is considered authenticated from the start. Currently, there is no support for providing authentication information separately through configuration.
-In order to send an email, users must specify the hostname or IP address of an SMTP server to connect to, the port to connect to, the email addresses to send the email to, and the email address to send from. These fields must be specified in the `notificationInfo` object in the configuration file.
+
+In order to send an email, users must specify the hostname or IP address of an SMTP server to connect to and the email addresses to send the email to. Optionally, users can specify the port to connect to and the email address to send from. These fields must be specified in the `notificationInfo` object in the configuration file. Below is more information on each field that can be specified. Further information can be found in the [`nodemailer` documentation](https://nodemailer.com/) for the [SMTP transport](https://nodemailer.com/smtp/) and [message configuration](https://nodemailer.com/message/).
+
+- `host`: The hostname or IP address of an SMTP server to connect to
+- `port`: The port to connect to (defaults to 587 if is secure is false or 465 if true)
+- `to`: Comma separated list or an array of recipients email addresses that will appear on the _To:_ field
+- `from`: The email address of the sender. All email addresses can be plain `'sender@server.com'` or formatted `'"Sender Name" sender@server.com'` (defaults to mcode-extraction-errors@mitre.org, which cannot receive reply emails)
+
 An example of this object can be found in [`config/icare-csv-config.example.json`](config/icare-csv-config.example.json).
 
-If the `notificationInfo` object is provided in configuration, an email will be sent using the specified options if any errors occur during data extraction. If any fields are missing in the object (`host`, `port`, `to`, or `from`), an email cannot be sent. If you prefer to not have email sent even if errors occur, you can choose to not include the `notificationInfo` object in your configuration file.
+If the `notificationInfo` object is provided in configuration, an email will be sent using the specified options if any errors occur during data extraction. If any required field is missing in the object (`host` or `to`), an email cannot be sent. If you prefer to not have an email sent even if errors occur, you can choose to not include the `notificationInfo` object in your configuration file.
 
 ## CSV Extraction
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ The connection to the SMTP server is considered authenticated from the start. Cu
 In order to send an email, users must specify the hostname or IP address of an SMTP server to connect to and the email addresses to send the email to. Optionally, users can specify the port to connect to and the email address to send from. These fields must be specified in the `notificationInfo` object in the configuration file. Below is more information on each field that can be specified. Further information can be found in the [`nodemailer` documentation](https://nodemailer.com/) for the [SMTP transport](https://nodemailer.com/smtp/) and [message configuration](https://nodemailer.com/message/).
 
 - `host`: The hostname or IP address of an SMTP server to connect to
-- `port`: The port to connect to (defaults to 587 if is secure is false or 465 if true)
+- `port`: (Optional) The port to connect to (defaults to 587)
 - `to`: Comma separated list or an array of recipients email addresses that will appear on the _To:_ field
-- `from`: The email address of the sender. All email addresses can be plain `'sender@server.com'` or formatted `'"Sender Name" sender@server.com'` (defaults to mcode-extraction-errors@mitre.org, which cannot receive reply emails)
+- `from`: (Optional) The email address of the sender. All email addresses can be plain `'sender@server.com'` or formatted `'"Sender Name" sender@server.com'` (defaults to mcode-extraction-errors@mitre.org, which cannot receive reply emails)
 
 An example of this object can be found in [`config/icare-csv-config.example.json`](config/icare-csv-config.example.json).
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Each extractor uses various methods to gather data and format that data into [mC
 - [cancer disease status](http://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-disease-status.html)
 - [care plan with review](http://standardhealthrecord.org/guides/icare/StructureDefinition-icare-care-plan-with-review.html)
 
+## Email Notification
+
+The ICARE Extraction Client supports sending an email using the SMTP protocol when there are errors during data extraction.
+In order to send an email, users must specify the hostname or IP address of an SMTP server to connect to, the port to connect to, the email addresses to send the email to, and the email address to send from. These fields must be specified in the `notificationInfo` object in the configuration file.
+An example of this object can be found in [`config/icare-csv-config.example.json`](config/icare-csv-config.example.json).
+
+If the `notificationInfo` object is provided in configuration, an email will be sent using the specified options if any errors occur during data extraction. If any fields are missing in the object (`host`, `port`, `to`, or `from`), an email cannot be sent. If you prefer to not have email sent even if errors occur, you can choose to not include the `notificationInfo` object in your configuration file.
+
 ## CSV Extraction
 
 In order to extract data elements from CSV files, in addition to the specifications above, your configuration file _must_ use the appropriate CSV Extractors for ICAREdata resources. An example configuration that specifies each extractor and its required configuration can be found in [`config/icare-csv-config.example.json`](config/icare-csv-config.example.json).

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -10,6 +10,12 @@
       "type": "example_userid_type"
     }
   },
+  "notificationInfo": {
+    "host": "smtp.example.com",
+    "port": 587,
+    "from": "sender@example.com",
+    "to": ["demo@example.com", "test@example.com"]
+  },
   "extractors": [
     {
       "label": "Display Label for Extractor",

--- a/config/icare-csv-config.example.json
+++ b/config/icare-csv-config.example.json
@@ -1,6 +1,12 @@
 {
   "patientIdCsvPath": "./data/csv/patient-mrns.csv",
   "commonExtractorArgs": {},
+  "notificationInfo": {
+    "host": "smtp.example.com",
+    "port": 587,
+    "from": "sender@example.com",
+    "to": ["demo@example.com", "test@example.com"]
+  },
   "extractors": [
     {
       "label": "condition",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5836,6 +5836,11 @@
         }
       }
     },
+    "nodemailer": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.11.tgz",
+      "integrity": "sha512-BVZBDi+aJV4O38rxsUh164Dk1NCqgh6Cm0rQSb9SK/DHGll/DrCMnycVDD7msJgZCnmVa8ASo8EZzR7jsgTukQ=="
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lodash": "^4.17.19",
     "mcode-extraction-framework": "git+https://github.com/mcode/mcode-extraction-framework.git",
     "moment": "^2.24.0",
+    "nodemailer": "^6.4.11",
     "uuid": "^7.0.2"
   },
   "devDependencies": {

--- a/src/helpers/cliUtils.js
+++ b/src/helpers/cliUtils.js
@@ -148,9 +148,9 @@ async function sendEmailNotification(notificationInfo, errors) {
     if (errors[patientRow].length === 0) {
       emailBody += 'No errors for this patient. Extraction was successful.\n';
     }
-    emailBody += '\n===================================================\n\n';
+    emailBody += '\n============================================================\n\n';
   });
-  emailBody += 'For more information about these errors, run the extraction client using the `--debug` flag';
+  emailBody += 'For more information about these errors, run the extraction client using the `--debug` flag.';
 
   const transporter = nodemailer.createTransport({
     host: notificationInfo.host,

--- a/src/helpers/cliUtils.js
+++ b/src/helpers/cliUtils.js
@@ -161,7 +161,7 @@ async function sendEmailNotification(notificationInfo, errors) {
   await transporter.sendMail({
     from: notificationInfo.from,
     to: notificationInfo.to,
-    subject: 'mCODE Extraction Client errors',
+    subject: 'mCODE Extraction Client Errors',
     text: emailBody,
   });
 }

--- a/src/helpers/cliUtils.js
+++ b/src/helpers/cliUtils.js
@@ -151,8 +151,9 @@ async function app(Client, fromDate, toDate, pathToConfig, pathToRunLogs, debug,
     logger.info(`Extracting data for ${patientIds.length} patients`);
     errors = await extractDataForPatients(auth, config, patientIds, icareClient, messagingClient, runLogger, effectiveFromDate, toDate);
 
+    const totalErrors = Object.keys(errors).reduce((previousValue, currentValue) => previousValue += errors[currentValue].length, 0);
     const { notificationInfo } = config;
-    if (notificationInfo) {
+    if (notificationInfo && totalErrors > 0) {
       if (!notificationInfo.from || !notificationInfo.to || !notificationInfo.host || !notificationInfo.port) {
         throw new Error('Notification information incomplete. Unable to send email.')
       }

--- a/test/helpers/cliUtils.test.js
+++ b/test/helpers/cliUtils.test.js
@@ -186,7 +186,7 @@ describe('cliUtils', () => {
         2: [],
       };
 
-      await expect(sendEmailNotification(notificationInfo, errors)).resolves.not.toThrow();
+      await expect(sendEmailNotification(notificationInfo, errors, false)).resolves.not.toThrow();
       expect(createTransportSpy).not.toBeCalled();
       expect(sendMailMock).not.toBeCalled();
     });
@@ -202,12 +202,37 @@ describe('cliUtils', () => {
       };
 
       const errorMessage = 'Email notification information incomplete. Unable to send email with 3 errors.';
-      await expect(sendEmailNotification(invalidNotificationInfo, errors)).rejects.toThrowError(errorMessage);
+      await expect(sendEmailNotification(invalidNotificationInfo, errors, false)).rejects.toThrowError(errorMessage);
       expect(createTransportSpy).not.toBeCalled();
       expect(sendMailMock).not.toBeCalled();
     });
 
-    it('should send an email according to config options with errors in the body', async () => {
+    it('should send an email according to minimal config options with errors in the body', async () => {
+      createTransportSpy.mockReturnValueOnce({ sendMail: sendMailMock });
+      const notificationInfo = {
+        host: 'my.host.com',
+        to: ['something@example.com', 'someone@example.com'],
+      };
+      const errors = {
+        0: [],
+        1: [{ message: 'something bad' }],
+        2: [{ message: 'an error' }, { message: 'another error' }],
+      };
+
+      await expect(sendEmailNotification(notificationInfo, errors, false)).resolves.not.toThrow();
+      expect(createTransportSpy).toBeCalledWith({ host: notificationInfo.host });
+      expect(sendMailMock).toBeCalled();
+      const sendMailMockArgs = sendMailMock.mock.calls[0][0];
+      expect(sendMailMockArgs.to).toEqual(notificationInfo.to);
+      expect(sendMailMockArgs.from).toEqual('mCODE Extraction Errors mcode-extraction-errors@mitre.org');
+      expect(sendMailMockArgs.subject).toEqual('mCODE Extraction Client Errors');
+      expect(sendMailMockArgs.text).toMatch(/This is an automated email/i);
+      expect(sendMailMockArgs.text).toMatch(/something bad/i);
+      expect(sendMailMockArgs.text).toMatch(/another error/i);
+      expect(sendMailMockArgs.text).toMatch(/run the extraction client using the `--debug`/i);
+    });
+
+    it('should send an email according to maximal config options with errors in the body', async () => {
       createTransportSpy.mockReturnValueOnce({ sendMail: sendMailMock });
       const notificationInfo = {
         host: 'my.host.com',
@@ -217,19 +242,46 @@ describe('cliUtils', () => {
       };
       const errors = {
         0: [],
-        1: [{ message: 'something bad' }],
-        2: [{ message: 'an error' }, { message: 'another error' }],
+        1: [{ message: 'something bad', stack: 'Error at line 1' }],
+        2: [{ message: 'an error', stack: 'Error at line 3' }, { message: 'another error', stack: 'Error at line 4' }],
       };
 
-      await expect(sendEmailNotification(notificationInfo, errors)).resolves.not.toThrow();
+      await expect(sendEmailNotification(notificationInfo, errors, false)).resolves.not.toThrow();
       expect(createTransportSpy).toBeCalledWith({ host: notificationInfo.host, port: notificationInfo.port });
       expect(sendMailMock).toBeCalled();
       const sendMailMockArgs = sendMailMock.mock.calls[0][0];
       expect(sendMailMockArgs.to).toEqual(notificationInfo.to);
       expect(sendMailMockArgs.from).toEqual(notificationInfo.from);
       expect(sendMailMockArgs.subject).toEqual('mCODE Extraction Client Errors');
+      expect(sendMailMockArgs.text).not.toMatch(/This is an automated email/i);
       expect(sendMailMockArgs.text).toMatch(/something bad/i);
       expect(sendMailMockArgs.text).toMatch(/another error/i);
+      expect(sendMailMockArgs.text).toMatch(/run the extraction client using the `--debug`/i);
+      expect(sendMailMockArgs.text).not.toMatch(/Error at line 1`/i);
+      expect(sendMailMockArgs.text).not.toMatch(/Error at line 4`/i);
+    });
+
+    it('should send an email with stack traces if debug flag was used', async () => {
+      createTransportSpy.mockReturnValueOnce({ sendMail: sendMailMock });
+      const notificationInfo = {
+        host: 'my.host.com',
+        port: 123,
+        to: ['something@example.com', 'someone@example.com'],
+        from: 'other@example.com',
+      };
+      const errors = {
+        0: [],
+        1: [{ message: 'something bad', stack: 'Error at line 1' }],
+        2: [{ message: 'an error', stack: 'Error at line 3' }, { message: 'another error', stack: 'Error at line 4' }],
+      };
+
+      await expect(sendEmailNotification(notificationInfo, errors, true)).resolves.not.toThrow();
+      expect(createTransportSpy).toBeCalledWith({ host: notificationInfo.host, port: notificationInfo.port });
+      expect(sendMailMock).toBeCalled();
+      const sendMailMockArgs = sendMailMock.mock.calls[0][0];
+      expect(sendMailMockArgs.text).not.toMatch(/run the extraction client using the `--debug`/i);
+      expect(sendMailMockArgs.text).toMatch(/Error at line 1/i);
+      expect(sendMailMockArgs.text).toMatch(/Error at line 4/i);
     });
   });
 });

--- a/test/helpers/cliUtils.test.js
+++ b/test/helpers/cliUtils.test.js
@@ -201,7 +201,7 @@ describe('cliUtils', () => {
         2: [{ message: 'an error' }, { message: 'another error' }],
       };
 
-      const errorMessage = 'Notification information incomplete. Unable to send email.';
+      const errorMessage = 'Email notification information incomplete. Unable to send email with 3 errors.';
       await expect(sendEmailNotification(invalidNotificationInfo, errors)).rejects.toThrowError(errorMessage);
       expect(createTransportSpy).not.toBeCalled();
       expect(sendMailMock).not.toBeCalled();


### PR DESCRIPTION
This PR supports sending an email with the list of extraction errors. If users want to be notified by email when errors occur, they must put the `notificationInfo` object in their configuration. They must specify a few fields in order to send an email as well. If no errors occur during extraction, no email is sent.

You can test this by adding `notificationInfo` to your configuration file and running the extraction using information that will produce errors. Any feedback on the content of the email is also appreciated.

I have two small questions about the set up I currently have:
- Technically the `port` is optional when setting up the nodemailer transport and it will default to port 587. Should I make it optional for the users as well? It seemed like maybe a good idea to have them explicitly list the port they are using, but I could change that easily if we'd prefer to use the default.
- Should I default an address that we send from? I don't think this field technically needs to be a valid email address, so I could put a placeholder or STEAM related one if that would be best.