### PR TITLE
Default no Run Logger

### DIFF
--- a/src/helpers/cliUtils.js
+++ b/src/helpers/cliUtils.js
@@ -189,7 +189,7 @@ async function app(Client, fromDate, toDate, pathToConfig, pathToRunLogs, debug,
 
   try {
     if (debug) logger.level = 'debug';
-    checkLogFile(pathToRunLogs);
+    if (!allEntries) checkLogFile(pathToRunLogs);
     const config = getConfig(pathToConfig);
     checkConfig(config, fromDate, toDate);
     const icareClient = new Client(config);
@@ -200,7 +200,7 @@ async function app(Client, fromDate, toDate, pathToConfig, pathToRunLogs, debug,
     // Get messaging client for messaging ICAREPlatform
     const messagingClient = new MessagingClient(config.awsConfig);
     // Get RunInstanceLogger for recording new runs and inferring dates from previous runs
-    const runLogger = new RunInstanceLogger(pathToRunLogs);
+    const runLogger = allEntries ? null : new RunInstanceLogger(pathToRunLogs);
     const effectiveFromDate = allEntries ? null : getEffectiveFromDate(fromDate, runLogger);
     const effectiveToDate = allEntries ? null : toDate;
 


### PR DESCRIPTION
Since extracting for all entries is the default behavior now, we shouldn't required that users have a `run-logs.json` file by default. The file is only required when the `--entries-filter` is used.