### PR TITLE
Upgrade MEF

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1118,8 +1118,7 @@
     "acorn": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
-      "dev": true
+      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w=="
     },
     "acorn-globals": {
       "version": "4.3.4",
@@ -1643,8 +1642,7 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -1962,8 +1960,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -2804,12 +2801,15 @@
       "version": "git+https://github.com/ICAREdata/fhir-messaging-client.git#4ce824f316858fb4e54cc8710e5c0b093940d585",
       "from": "git+https://github.com/ICAREdata/fhir-messaging-client.git",
       "requires": {
+        "acorn": "^7.1.1",
         "axios": "^0.19.0",
         "commander": "^4.0.1",
         "dotenv": "^8.2.0",
-        "node-forge": "0.10.0",
+        "minimist": "^1.2.3",
+        "node-forge": "^0.10.0",
         "node-jose": "^1.1.3",
-        "uuid": "^8.0.0"
+        "uuid": "^8.0.0",
+        "yargs-parser": "^18.1.2"
       },
       "dependencies": {
         "uuid": {
@@ -5570,7 +5570,7 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#37da48cdbff7a16a7eadebb0ccf14752a339e877",
+      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#b89d7acc6362109ad6d6168a431d13fa9ea86b7b",
       "from": "git+https://github.com/mcode/mcode-extraction-framework.git",
       "requires": {
         "axios": "^0.19.0",
@@ -5632,8 +5632,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -7950,7 +7949,6 @@
       "version": "18.1.3",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
       "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2798,7 +2798,7 @@
       }
     },
     "fhir-messaging-client": {
-      "version": "git+https://github.com/ICAREdata/fhir-messaging-client.git#4ce824f316858fb4e54cc8710e5c0b093940d585",
+      "version": "git+https://github.com/ICAREdata/fhir-messaging-client.git#ede6108cff5df75dc4d97678bdb0c7c003c17ab4",
       "from": "git+https://github.com/ICAREdata/fhir-messaging-client.git",
       "requires": {
         "acorn": "^7.1.1",


### PR DESCRIPTION
Upgrade to latest MEF commit. I believe the additional changes are from upgrades to fhir-messaging-client, but I'm not 100% sure because the commit hash for that repo hasn't changed. If anyone doesn't think those should be here or can upgrade MEF without getting those changes, I can close this PR.