### PR TITLE
Medication Extractor added

### DIFF
--- a/data/csv/cancer-related-medication-information.csv
+++ b/data/csv/cancer-related-medication-information.csv
@@ -1,4 +1,4 @@
-mrn,medicationId,code,codeSystem,displayText,startDate,endDate,treatmentReasonCode,treatmentReasonCodeSystem,treatmentReasonDisplayText,treatmentIntent
-123,medicationId-1,10760,http://www.nlm.nih.gov/research/umls/rxnorm,Triamcinolone Oral Paste,2020-01-01,2020-07-05,134006,http://snomed.info/sct,Decreased hair growth,373808002
-456,medicationId-2,91318,http://www.nlm.nih.gov/research/umls/rxnorm,Coal Tar Topical Solution,2020-02-17,2020-08-13,188001,http://snomed.info/sct,Intercostal artery injury,373808002
-789,medicationId-3,91833,http://www.nlm.nih.gov/research/umls/rxnorm,Vitamin K1 Injectable Solution [Aquamephyton],2020-01-12,2020-10-01,228007,http://snomed.info/sct,Lucio phenomenon,363676003
+mrn,medicationId,code,codeSystem,displayText,startDate,endDate,treatmentReasonCode,treatmentReasonCodeSystem,treatmentReasonDisplayText,treatmentIntent,status
+123,medicationId-1,10760,http://www.nlm.nih.gov/research/umls/rxnorm,Triamcinolone Oral Paste,2020-01-01,2020-07-05,134006,http://snomed.info/sct,Decreased hair growth,373808002,active
+456,medicationId-2,91318,http://www.nlm.nih.gov/research/umls/rxnorm,Coal Tar Topical Solution,2020-02-17,2020-08-13,188001,http://snomed.info/sct,Intercostal artery injury,373808002,completed
+789,medicationId-3,91833,http://www.nlm.nih.gov/research/umls/rxnorm,Vitamin K1 Injectable Solution [Aquamephyton],2020-01-12,2020-10-01,228007,http://snomed.info/sct,Lucio phenomenon,363676003,intended

--- a/data/csv/cancer-related-medication-information.csv
+++ b/data/csv/cancer-related-medication-information.csv
@@ -1,0 +1,4 @@
+mrn,medicationId,code,codeSystem,displayText,startDate,endDate,treatmentReasonCode,treatmentReasonCodeSystem,treatmentReasonDisplayText,treatmentIntent
+123,medicationId-1,10760,http://www.nlm.nih.gov/research/umls/rxnorm,Triamcinolone Oral Paste,2020-01-01,2020-07-05,134006,http://snomed.info/sct,Decreased hair growth,373808002
+456,medicationId-2,91318,http://www.nlm.nih.gov/research/umls/rxnorm,Coal Tar Topical Solution,2020-02-17,2020-08-13,188001,http://snomed.info/sct,Intercostal artery injury,373808002
+789,medicationId-3,91833,http://www.nlm.nih.gov/research/umls/rxnorm,Vitamin K1 Injectable Solution [Aquamephyton],2020-01-12,2020-10-01,228007,http://snomed.info/sct,Lucio phenomenon,363676003

--- a/package-lock.json
+++ b/package-lock.json
@@ -1189,6 +1189,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1295,9 +1296,9 @@
       "dev": true
     },
     "async": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1455,7 +1456,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -1535,6 +1537,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1655,6 +1658,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1828,7 +1832,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "confusing-browser-globals": {
       "version": "1.0.9",
@@ -2083,14 +2088,6 @@
         "safer-buffer": "^2.1.0"
       }
     },
-    "ejs": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.5.tgz",
-      "integrity": "sha512-dldq3ZfFtgVTJMLjOe+/3sROTzALlL9E34V4/sDtUd/KlBSS0s6U1/+WPE1B4sj9CXHJpL1M6rhNJnc9Wbal9w==",
-      "requires": {
-        "jake": "^10.6.1"
-      }
-    },
     "emitter-component": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
@@ -2168,7 +2165,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.14.3",
@@ -2848,14 +2846,6 @@
         "flat-cache": "^2.0.1"
       }
     },
-    "filelist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz",
-      "integrity": "sha512-8zSK6Nu0DQIC08mUC46sWGXi+q3GGpKydAG36k+JDba6VRpkevvOWUW5a/PhShij4+vHT9M+ghgG7eM+a9JDUQ==",
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3084,7 +3074,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -3707,17 +3698,6 @@
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
-      }
-    },
-    "jake": {
-      "version": "10.8.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
-      "integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
-      "requires": {
-        "async": "0.9.x",
-        "chalk": "^2.4.2",
-        "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
       }
     },
     "jest": {
@@ -5562,12 +5542,11 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#324c4138620689ff23aba9069f2b1fbb160a4d57",
+      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#f286a1594bfa893189f8c37caa0d5116e556145a",
       "from": "git+https://github.com/mcode/mcode-extraction-framework.git",
       "requires": {
         "axios": "^0.19.0",
         "csv-parse": "^4.8.8",
-        "ejs": "^3.0.1",
         "fhir-crud-client": "^1.2.1",
         "fhirpath": "^2.1.5",
         "lodash": "^4.17.19",
@@ -5617,6 +5596,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -7220,6 +7200,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -7713,11 +7694,6 @@
         "winston-transport": "^4.4.0"
       },
       "dependencies": {
-        "async": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
-        },
         "is-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",

--- a/src/ICARECSVClient.js
+++ b/src/ICARECSVClient.js
@@ -6,6 +6,7 @@ const {
   CSVClinicalTrialInformationExtractor,
   CSVPatientExtractor,
   CSVTreatmentPlanChangeExtractor,
+  CSVCancerRelatedMedicationExtractor,
 } = require('mcode-extraction-framework');
 const { generateNewMessageBundle } = require('./helpers/icareBundling');
 
@@ -19,6 +20,7 @@ class ICARECSVClient extends BaseClient {
       CSVPatientExtractor,
       CSVTreatmentPlanChangeExtractor,
       CSVObservationExtractor,
+      CSVCancerRelatedMedicationExtractor,
     );
 
     this.commonExtractorArgs = {


### PR DESCRIPTION
Support for the CancerRelatedMedication resource has been added. As a reminder, this should be tested against the corresponding PR on the `mcode-extraction-framework` repo. Happy testing!

**Note: To test, this entry should be added to the `extractors` array within `csv.config.json`: 

```
 {
       "label": "medication",
       "type": "CSVCancerRelatedMedicationExtractor",
       "constructorArgs": {
         "filePath": "./data/csv/cancer-related-medication-information.csv"
       }
 }
```