### PR TITLE
Cli and config changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ After exporting your CSV files to the `data` directory, kickstart the creation o
 2. For each extractor, `filePath:` should provide a file path to a CSV file containing that corresponding extractor's data;
 3. For the ClinicalInformationExtractor, `clinicalSiteID` should correspond to the researchId used by your clinical site in support of the ICAREdata trial;
 4. The `awsConfig` object needs to be updated - according to the [fhir-messaging-client spec](https://github.com/ICAREdata/fhir-messaging-client) - to include the following fields:
-   - A `baseURL` field that indicates the base URL of the server to post messages to,
+   - A `baseURL` field that indicates the base URL of the server to post messages to.
    - A `clientId` field containing the client ID that is registered for the ICAREdata OAuth2 framework.
    - An `aud` field containing the audience parameter that is registered for the client in the ICAREdata OAuth2 framework.
    - And private-key information corresponding to the registered client in the ICAREdata OAuth2 framework, which can be provided in two formats:

--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ If the `notificationInfo` object is provided in configuration, an email will be 
 
 Whenever the ICARE Extraction Client successfully runs, a log is kept of the given date range of the extraction. Users will need to specify the location of the file to save this information. The default location is in a `logs` directory in a file called `run-logs.json`. Initially, this file's contents should be an empty array, `[]`. Users will need to create this file before running the ICARE Extraction Client with `from-date` and/or `to-date` for the first time.
 
-Users can specify a different location for the file by using the `--path-to-run-logs <path>` CLI option. For example:
+Users can specify a different location for the file by using the `--run-log-filepath <path>` CLI option. For example:
 
 ```bash
-node src/cli.js --path-to-run-logs path/to/file.json
+node src/cli.js --run-log-filepath path/to/file.json
 ```
 
 ## Extraction Date Range
@@ -114,7 +114,7 @@ If any filtering on data elements in CSV files is required, the `entries-filter`
 If a `from-date` is provided as an option when running the ICARE Extraction Client, it will be used to filter out any data elements that are recorded before that date based on the `dateRecorded` column in the CSV files. If a `to-date` is provided as an option, it will be used to filter out any data elements that are recorded after that date based on the `dateRecorded` column in the CSV files. If no `to-date` is provided, the default is today. If no `from-date` is provided, the ICARE Extraction Client will look to a run log file (details [above](#Logging-Successful-Extractions)) to find the most recent run and use the `to-date` of that run as the `from-date` for the current run, allowing users to only run the extraction on data elements that were not included in previous runs. If there are no previous run times logged, a `from-date` needs to be provided when running the extraction when the `entries-filter` option is provided. If the `entries-filter` option is not provided, any `from-date` and `to-date` options will be ignored, none of the data elements will be filtered by date, and a successful run will not be logged since there is no specified date range. An example running the client with the `from-date` and `to-date` is as follows:
 
 ```bash
-node src/cli.js --entries-filter --from-date <YYYY-MM-DD> --to-date <YYYY-MM-DD> --path-to-config <path-to-config-file>
+node src/cli.js --entries-filter --from-date <YYYY-MM-DD> --to-date <YYYY-MM-DD> --config-filepath <path>
 ```
 
 ## Developer Guide

--- a/src/cli.js
+++ b/src/cli.js
@@ -17,7 +17,7 @@ program
   .parse(process.argv);
 
 const {
-  fromDate, toDate, pathToConfig, pathToRunLogs, debug, entriesFilter,
+  fromDate, toDate, configFilepath, runLogFilepath, debug, entriesFilter,
 } = program;
 
-app(ICARECSVClient, fromDate, toDate, pathToConfig, pathToRunLogs, debug, null, !entriesFilter);
+app(ICARECSVClient, fromDate, toDate, configFilepath, runLogFilepath, debug, null, !entriesFilter);

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,8 +11,8 @@ program
   .option('-f --from-date <date>', 'The earliest date and time to search')
   .option('-t --to-date <date>', 'The latest date and time to search')
   .option('-e, --entries-filter', 'Flag to indicate to filter data by date')
-  .option('-p --path-to-config <path>', 'Specify relative path to config to use:', defaultPathToConfig)
-  .option('-l --path-to-run-logs <path>', 'Specify relative path to log file of previous runs:', defaultPathToRunLogs)
+  .option('-c --config-filepath <path>', 'Specify relative path to config to use:', defaultPathToConfig)
+  .option('-r --run-log-filepath <path>', 'Specify relative path to log file of previous runs:', defaultPathToRunLogs)
   .option('-d, --debug', 'output extra debugging information')
   .parse(process.argv);
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -20,4 +20,7 @@ const {
   fromDate, toDate, configFilepath, runLogFilepath, debug, entriesFilter,
 } = program;
 
-app(ICARECSVClient, fromDate, toDate, configFilepath, runLogFilepath, debug, null, !entriesFilter);
+// Flag for if webServices are used by the client & auth is required
+const isUsingWebServices = false;
+
+app(ICARECSVClient, fromDate, toDate, configFilepath, runLogFilepath, debug, !entriesFilter, isUsingWebServices);

--- a/src/helpers/cliUtils.js
+++ b/src/helpers/cliUtils.js
@@ -81,9 +81,9 @@ function getEffectiveFromDate(fromDate, runLogger) {
   return effectiveFromDate;
 }
 
-async function extractDataForPatients(auth, config, patientIds, icareClient, messagingClient, runLogger, fromDate, toDate) {
-  if (auth) {
-    await icareClient.initAuth(config.auth);
+async function extractDataForPatients(isUsingWebServices, config, patientIds, icareClient, messagingClient, runLogger, fromDate, toDate) {
+  if (isUsingWebServices) {
+    await icareClient.initAuth(config.webServiceAuthConfig);
   }
 
   await checkMessagingClient(messagingClient);
@@ -184,11 +184,12 @@ async function sendEmailNotification(notificationInfo, errors, debug) {
   });
 }
 
-async function app(Client, fromDate, toDate, pathToConfig, pathToRunLogs, debug, auth, allEntries) {
+async function app(Client, fromDate, toDate, pathToConfig, pathToRunLogs, debug, allEntries, isUsingWebServices) {
   let errors = {};
 
   try {
     if (debug) logger.level = 'debug';
+    // Don't require a run-logs file if we are extracting all-entries. Only required when using --entries-filter.
     if (!allEntries) checkLogFile(pathToRunLogs);
     const config = getConfig(pathToConfig);
     checkConfig(config, fromDate, toDate);
@@ -205,7 +206,7 @@ async function app(Client, fromDate, toDate, pathToConfig, pathToRunLogs, debug,
     const effectiveToDate = allEntries ? null : toDate;
 
     logger.info(`Extracting data for ${patientIds.length} patients`);
-    errors = await extractDataForPatients(auth, config, patientIds, icareClient, messagingClient, runLogger, effectiveFromDate, effectiveToDate);
+    errors = await extractDataForPatients(isUsingWebServices, config, patientIds, icareClient, messagingClient, runLogger, effectiveFromDate, effectiveToDate);
 
     const { notificationInfo } = config;
     if (notificationInfo) {

--- a/src/helpers/cliUtils.js
+++ b/src/helpers/cliUtils.js
@@ -34,7 +34,7 @@ function checkLogFile(pathToLogs) {
     const logFileContent = JSON.parse(fs.readFileSync(pathToLogs));
     if (!Array.isArray(logFileContent)) throw new Error('Log file needs to be an array.');
   } catch (err) {
-    logger.error(`-l/--path-to-run-logs value of ${pathToLogs} did not point to a valid JSON file. Create a json file with an empty array.`);
+    logger.error(`The provided filepath to a LogFile, ${pathToLogs}, did not point to a valid JSON file. Create a json file with an empty array at this location.`);
     throw new Error(err.message);
   }
 }
@@ -62,7 +62,7 @@ function getConfig(pathToConfig) {
   try {
     return JSON.parse(fs.readFileSync(fullPath));
   } catch (err) {
-    throw new Error(`-p/--path-to-config value of ${pathToConfig}, full path ${fullPath} did not point to a valid JSON file.`);
+    throw new Error(`The provided filepath to a configuration file, ${pathToConfig} with full path ${fullPath}, did not point to a valid JSON file.`);
   }
 }
 

--- a/test/helpers/cliUtils.test.js
+++ b/test/helpers/cliUtils.test.js
@@ -115,12 +115,12 @@ describe('cliUtils', () => {
       get: jest.fn(),
     }))();
 
-    it('should call icareClient.initAuth with testConfig.auth when auth is true', async () => {
+    it('should call icareClient.initAuth with testConfig.webServiceAuthConfig when isUsingWebServices is true', async () => {
       await expect(extractDataForPatients(true, testConfig, testPatientIds, mockIcareClient)).rejects.toThrowError();
       expect(mockIcareClient.initAuth).toHaveBeenCalledWith('example-auth');
     });
 
-    it('should not call icareClient.initAuth when auth is false', async () => {
+    it('should not call icareClient.initAuth when isUsingWebServices is false', async () => {
       mockIcareClient.initAuth.mockClear();
       await expect(extractDataForPatients(false, testConfig, testPatientIds, mockIcareClient)).rejects.toThrowError();
       expect(mockIcareClient.initAuth).not.toHaveBeenCalled();

--- a/test/helpers/fixtures/test-config.json
+++ b/test/helpers/fixtures/test-config.json
@@ -1,5 +1,5 @@
 {
   "awsConfig": "example-aws-config",
   "patientIdCsvPath": "example-patient-id-csv-path",
-  "auth": "example-auth"
+  "webServiceAuthConfig": "example-auth"
 }


### PR DESCRIPTION
Addressed STEAM-386 and STEAM-387, by introducing the following changes: 
- Config filepath CLI arg is now `-c` instead of `-p`;
- RunLog filepath CLI arg is now `-r` instead of `-l`;
- Changed the order of parameters into  `app()` for simplicity on the [Epic-MEF repo](https://gitlab.mitre.org/mcode/epic-icare-extraction-client);
- Update fixtures with new configuration file format;
- Syntax in the readme.

Make sure you update your config file before testing to avoid issues with the new expected config fields. 

One reviewer should be sufficient!