### PR TITLE
Improve fhirMessagingClient.processMessage error handling

### DIFF
--- a/src/icareFhirMessaging.js
+++ b/src/icareFhirMessaging.js
@@ -111,8 +111,11 @@ async function postExtractedData(messagingClient, bundledData) {
       } catch (e2) {
         // We're provided an error that was produced before or after the process message function;
         // Handle this as a special case
-        logger.error(`ERROR - ${e2.message}`);
+        logger.error(`ERROR - could not parse processMessage response as expected, failed and produced "${e2.message}"
+        processMessage error has status ${e.status} and message "${e.message}"
+        `);
         logger.debug(e2.stack);
+        logger.debug(e.stack);
       }
     }
   });


### PR DESCRIPTION
Previously we would throw uncaught exceptions when the error message triggered by 
`messagingClient.processMessage(bundle)` did not conform to the error format defined by the ICAREdata-platform. This happens when errors occur at the Authorization step in the ICAREdata-platform api gateway. To ensure that we handle these un-schematized errors appropriately, we add another catch block and display a helpful amount of information to the CLI. 