### PR TITLE
Update MEF dependency hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2775,21 +2775,6 @@
         "axios": "^0.21.1",
         "lodash": "^4.17.15",
         "url-join": "^4.0.1"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.21.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-          "requires": {
-            "follow-redirects": "^1.10.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
-        }
       }
     },
     "fhir-messaging-client": {
@@ -5543,7 +5528,7 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#59682bfcbecb11cad49460636469c4dbf7e11c8e",
+      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#8c77023cd63f0655ace0ef4fa407e9c8c6e2754e",
       "from": "git+https://github.com/mcode/mcode-extraction-framework.git",
       "requires": {
         "ajv": "^6.12.6",


### PR DESCRIPTION
New update includes the changes to the CarePlan template.

See https://github.com/ICAREdata/icaredata-platform/pull/41