### PR TITLE
Add test-flag to ICARE App

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,6 @@ Users can specify a different location for the file by using the `--run-log-file
 node src/cli.js --run-log-filepath path/to/file.json
 ```
 
-## Extraction Date Range
-
-The ICARE Extraction Client will extract all data that is provided in the CSV files by default, regardless of any dates associated with each row of data. It is recommended that any required date filtering is performed outside of the scope of this client.
-
-If for any reason a user is required to specify a date range to be extracted through this client, users _must_ add a `dateRecorded` column in every data CSV file. This column will indicate when each row of data was added to the CSV file. Note that this date _does not_ correspond to any date associated with the data element.
-
 ## Test Flight
 
 In order to test the extraction of ICARE data without posting to an ICAREdata AWS environment, use the `--test-flight` CLI option. For example:
@@ -116,6 +110,12 @@ node src/cli.js --test-flight
 ```
 
 When this flag is used, the ICARE Extraction Client will execute full extraction using any extractors specified in the configuration file. However, no data will be sent to the AWS environment specified in the configuration file and no data will be output to a file. This flag is intended to be used for debugging and ensuring extraction is successful before posting any data.
+
+## Extraction Date Range
+
+The ICARE Extraction Client will extract all data that is provided in the CSV files by default, regardless of any dates associated with each row of data. It is recommended that any required date filtering is performed outside of the scope of this client.
+
+If for any reason a user is required to specify a date range to be extracted through this client, users _must_ add a `dateRecorded` column in every data CSV file. This column will indicate when each row of data was added to the CSV file. Note that this date _does not_ correspond to any date associated with the data element.
 
 ### CLI From-Date and To-Date (NOT recommended use)
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ After exporting your CSV files to the `data` directory, kickstart the creation o
 1. `patientIdCsvPath` should provide a file path to a CSV file containing MRN's for relevant patients;
 2. For each extractor, `filePath:` should provide a file path to a CSV file containing that corresponding extractor's data;
 3. For the ClinicalInformationExtractor, `clinicalSiteID` should correspond to the researchId used by your clinical site in support of the ICAREdata trial;
-3. The `awsConfig` object needs to be updated to include the following fields with information that is sent separately by the ICAREdata team:
+4. The `awsConfig` object needs to be updated to include the following fields with information that is sent separately by the ICAREdata team:
    - A `baseURL` field that indicates the base URL of the server to post messages to.
    - A `clientId` field containing the client ID that is registered for the ICAREdata OAuth2 framework.
    - An `aud` field containing the audience parameter that is registered for the client in the ICAREdata OAuth2 framework.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ The ICARE Extraction Client will extract all data that is provided in the CSV fi
 
 If for any reason a user is required to specify a date range to be extracted through this client, users _must_ add a `dateRecorded` column in every data CSV file. This column will indicate when each row of data was added to the CSV file. Note that this date _does not_ correspond to any date associated with the data element.
 
+## Test Flight
+
+In order to test the extraction of ICARE data without posting to an ICAREdata AWS environment, use the `--test-flight` CLI option. For example:
+
+```bash
+node src/cli.js --test-flight
+```
+
+When this flag is used, the ICARE Extraction Client will execute full extraction using any extractors specified in the configuration file. However, no data will be sent to the AWS environment specified in the configuration file and no data will be output to a file. This flag is intended to be used for debugging and ensuring extraction is successful before posting any data.
+
 ### CLI From-Date and To-Date (NOT recommended use)
 
 If any filtering on data elements in CSV files is required, the `entries-filter` option must be used. The remaining instructions in this section assume this flag is provided.

--- a/src/app.js
+++ b/src/app.js
@@ -18,7 +18,7 @@ function getConfig(pathToConfig) {
   }
 }
 
-function checkInputAndConfig(config, fromDate, toDate) {
+function checkInputAndConfig(config, fromDate, toDate, testFlight) {
   // Check input args and needed config variables based on client being used
   const { patientIdCsvPath, awsConfig } = config;
 
@@ -33,8 +33,13 @@ function checkInputAndConfig(config, fromDate, toDate) {
   }
 
   // Check if there is a path to the MRN CSV and a path to the AWS config within our config file
-  if (!awsConfig || !patientIdCsvPath) {
-    throw new Error('patientIdCsvPath, awsConfig are required in config file');
+  if (!patientIdCsvPath) {
+    throw new Error('patientIdCsvPath is required in config file');
+  }
+
+  // AWS config is not required during test flight runs
+  if (!testFlight && !awsConfig) {
+    throw new Error('awsConfig is required in config file');
   }
 }
 
@@ -74,7 +79,7 @@ async function icareApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, d
     // Don't require a run-logs file if we are extracting all-entries. Only required when using --entries-filter.
     if (!allEntries) checkLogFile(pathToRunLogs);
     const config = getConfig(pathToConfig);
-    checkInputAndConfig(config, fromDate, toDate);
+    checkInputAndConfig(config, fromDate, toDate, testFlight);
 
     // Create and initialize client
     const icareClient = new Client(config);

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,8 +13,8 @@ program
   .option('-e, --entries-filter', 'Flag to indicate to filter data by date')
   .option('-c --config-filepath <path>', 'Specify relative path to config to use:', defaultPathToConfig)
   .option('-r --run-log-filepath <path>', 'Specify relative path to log file of previous runs:', defaultPathToRunLogs)
-  .option('-d, --debug', 'output extra debugging information')
-  .option('--test-flight', 'only extract data but do not post it')
+  .option('-d, --debug', 'Output extra debugging information')
+  .option('--test-flight', 'Flag to test extraction without posting to AWS')
   .parse(process.argv);
 
 const {

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,13 +14,14 @@ program
   .option('-c --config-filepath <path>', 'Specify relative path to config to use:', defaultPathToConfig)
   .option('-r --run-log-filepath <path>', 'Specify relative path to log file of previous runs:', defaultPathToRunLogs)
   .option('-d, --debug', 'output extra debugging information')
+  .option('--test-flight', 'only extract data but do not post it')
   .parse(process.argv);
 
 const {
-  fromDate, toDate, configFilepath, runLogFilepath, debug, entriesFilter,
+  fromDate, toDate, configFilepath, runLogFilepath, debug, entriesFilter, testFlight,
 } = program;
 
 // Flag to extract allEntries, or just to use to-from dates
 const allEntries = !entriesFilter;
 
-icareApp(ICARECSVClient, fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries);
+icareApp(ICARECSVClient, fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries, testFlight);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -39,7 +39,7 @@ describe('appUtils', () => {
       delete awsMissingConfig.awsConfig;
       expect(() => checkInputAndConfig(awsMissingConfig, '2020-06-01', '2020-06-30', false)).toThrowError('awsConfig is required in config file');
     });
-    it('should not throw an error if awsConfig is missing when not in a test flight', () => {
+    it('should not throw an error if awsConfig is missing when in a test flight', () => {
       const awsMissingConfig = { ...testConfig };
       delete awsMissingConfig.awsConfig;
       expect(() => checkInputAndConfig(awsMissingConfig, '2020-06-01', '2020-06-30', true)).not.toThrowError();

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -30,10 +30,22 @@ describe('appUtils', () => {
       expect(() => checkInputAndConfig(testConfig, '2020-06-30', '2020-06-31')).toThrowError('-t/--to-date is not a valid date.');
     });
     it('should throw error when patientIdCsvPath not provided in config', () => {
-      expect(() => checkInputAndConfig({})).toThrowError('patientIdCsvPath, awsConfig are required in config file');
+      const patientCsvPathMissingConfig = { ...testConfig };
+      delete patientCsvPathMissingConfig.patientIdCsvPath;
+      expect(() => checkInputAndConfig(patientCsvPathMissingConfig)).toThrowError('patientIdCsvPath is required in config file');
+    });
+    it('should throw an error if awsConfig is missing when not in a test flight', () => {
+      const awsMissingConfig = { ...testConfig };
+      delete awsMissingConfig.awsConfig;
+      expect(() => checkInputAndConfig(awsMissingConfig, '2020-06-01', '2020-06-30', false)).toThrowError('awsConfig is required in config file');
+    });
+    it('should not throw an error if awsConfig is missing when not in a test flight', () => {
+      const awsMissingConfig = { ...testConfig };
+      delete awsMissingConfig.awsConfig;
+      expect(() => checkInputAndConfig(awsMissingConfig, '2020-06-01', '2020-06-30', true)).not.toThrowError();
     });
     it('should not throw error when all args are valid', () => {
-      expect(() => checkInputAndConfig(testConfig, '2020-06-01', '2020-06-30')).not.toThrowError();
+      expect(() => checkInputAndConfig(testConfig, '2020-06-01', '2020-06-30', false)).not.toThrowError();
     });
   });
 


### PR DESCRIPTION
This PR adds a new flag to the CLI `--test-flight`. When using this flag, the app will not create an ICARE messaging client or try to post data to AWS. I also disabled the run logger and the email notifications in this case since it's just a practice run where someone is likely watching for any extraction errors. I also didn't add a short option to the CLI option because it seemed like a flag that we would want to be explicit about turning on (also, there are no good letters).