### PR TITLE
Email configuration options update

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ The connection to the SMTP server is considered authenticated from the start. Cu
 
 In order to send an email, users must specify the hostname or IP address of an SMTP server to connect to and the email addresses to send the email to. Optionally, users can specify the port to connect to and the email address to send from. These fields must be specified in the `notificationInfo` object in the configuration file. Below is more information on each field that can be specified. Further information can be found in the [`nodemailer` documentation](https://nodemailer.com/) for the [SMTP transport](https://nodemailer.com/smtp/) and [message configuration](https://nodemailer.com/message/).
 
-- `host`: The hostname or IP address of an SMTP server to connect to
-- `port`: (Optional) The port to connect to (defaults to 587)
-- `to`: Comma separated list or an array of recipients email addresses that will appear on the _To:_ field
-- `from`: (Optional) The email address of the sender. All email addresses can be plain `'sender@server.com'` or formatted `'"Sender Name" sender@server.com'` (defaults to mcode-extraction-errors@mitre.org, which cannot receive reply emails)
+- `host`: `<string>` The hostname or IP address of an SMTP server to connect to
+- `port`: `<number>` (Optional) The port to connect to (defaults to 587)
+- `to`: `<string[]>` Comma separated list or an array of recipients email addresses that will appear on the _To:_ field
+- `from`: `<string>` (Optional) The email address of the sender. All email addresses can be plain `'sender@server.com'` or formatted `'"Sender Name" sender@server.com'` (defaults to mcode-extraction-errors@mitre.org, which cannot receive reply emails)
+- `tlsRejectUnauthorized`: `<boolean>` (Optional) A boolean value to set the [node.js TLSSocket option](https://nodejs.org/api/tls.html#tls_class_tls_tlssocket) for rejecting any unauthorized connections, `tls.rejectUnauthorized`.  (defaults to `true`)
 
 An example of this object can be found in [`config/csv.config.example.json`](config/csv.config.example.json).
 
@@ -114,6 +115,23 @@ node src/cli.js --test-flight
 ```
 
 When this flag is used, the ICARE Extraction Client will execute full extraction using any extractors specified in the configuration file. However, no data will be sent to the AWS environment specified in the configuration file and no data will be output to a file. This flag is intended to be used for debugging and ensuring extraction is successful before posting any data.
+
+## Masking Patient Data
+
+Patient data can be masked within the extracted `Patient` resource. When masked, the value of the field will be replaced with a [Data Absent Reason extension](https://www.hl7.org/fhir/extension-data-absent-reason.html) with the code `masked`.
+Patient properties that can be masked are: `gender`, `mrn`, `name`, `address`, `birthDate`, `language`, `ethnicity`, `birthsex`, and `race`.
+To mask a property, provide an array of the properties to mask in the `constructorArgs` of the Patient extractor. For example, the following configuration can be used to mask `address` and `birthDate`:
+
+```bash
+{
+  "label": "patient",
+  "type": "CSVPatientExtractor",
+  "constructorArgs": {
+    "filePath": "./data/patient-information.csv"
+    "mask": ["address", "birthDate"]
+  }
+}
+```
 
 ## Extraction Date Range
 

--- a/config/csv.config.example.json
+++ b/config/csv.config.example.json
@@ -8,7 +8,8 @@
     "to": [
       "demo@example.com",
       "test@example.com"
-    ]
+    ],
+    "tlsRejectUnauthorized": true
   },
   "extractors": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5528,7 +5528,7 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#3723dc13307a1da0941a41ab26869bed9b6f7793",
+      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#4bf88aae6681d9c48e343afbca2c7499deea1d90",
       "from": "git+https://github.com/mcode/mcode-extraction-framework.git",
       "requires": {
         "ajv": "^6.12.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1787,9 +1787,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-      "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
+      "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -5528,7 +5528,7 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#a415c1ed57a9caa7240dab4123fc9e5739c6677e",
+      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#3723dc13307a1da0941a41ab26869bed9b6f7793",
       "from": "git+https://github.com/mcode/mcode-extraction-framework.git",
       "requires": {
         "ajv": "^6.12.6",

--- a/test/ICARECSVClient.test.js
+++ b/test/ICARECSVClient.test.js
@@ -15,8 +15,8 @@ const testConfig = {
       label: 'condition',
       type: 'CSVConditionExtractor',
       constructorArgs: {
-        // These CSV paths don't point at actual data, but valid files are needed to avoid parser errors
-        filePath: path.join(__dirname, './fixtures/csv/example.csv'),
+        // This CSV path doesn't point at actual data, but a valid file with valid columns is needed to avoid CSV parser and CSV validation errors
+        filePath: path.join(__dirname, './fixtures/csv/example-condition.csv'),
       },
     },
   ],

--- a/test/fixtures/csv/example-condition.csv
+++ b/test/fixtures/csv/example-condition.csv
@@ -1,0 +1,2 @@
+mrn,conditionId,codeSystem,code,displayName,category,dateOfDiagnosis,clinicalStatus,verificationStatus,bodySite,laterality,histology
+example,values,a,b,c,d,e,f,g,h,i,j

--- a/test/fixtures/csv/example.csv
+++ b/test/fixtures/csv/example.csv
@@ -1,2 +1,0 @@
-example,columns
-example,values


### PR DESCRIPTION
This PR updates the version of MEF in order to support the latest email configuration options (`tlsRejectUnauthorized`). It also adds the readme updates for the new email option, the patient masked data, and the property in the example configuration.

Because the latest MEF version is used, the CSV Condition Extractor now validates the CSV file it uses, so the test fixture used was updated to include the valid columns.

Test by ensuring you can use the new email configuration option in your config file and successfully send emails if you are using the NODE_EXTRA_CA_CERTS.