### PR TITLE
Add test-aws-auth flag to ICARE App

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Users can specify a different location for the file by using the `--run-log-file
 node src/cli.js --entries-filter --from-date YYYY-MM-DD --to-date YYY-MM-DD --run-log-filepath path/to/file.json
 ```
 
-## Test Flight
+## Testing Extraction and AWS Authentication
 
 In order to test the extraction of ICARE data without posting to an ICAREdata AWS environment, use the `--test-extraction` CLI option. For example:
 
@@ -115,6 +115,14 @@ node src/cli.js --test-extraction
 ```
 
 When this flag is used, the ICARE Extraction Client will execute full extraction using any extractors specified in the configuration file. However, no data will be sent to the AWS environment specified in the configuration file and no data will be output to a file. This flag is intended to be used for debugging and ensuring extraction is successful before posting any data.
+
+In order to test authentication to the AWS environment specified in the configuration file, use the `--test-aws-auth` CLI option. For example:
+
+```bash
+node src/cli.js --test-aws-auth
+```
+
+When this flag is used, the ICARE Extraction Client will try to connect to and authorize the AWS environment specified in the configuration file. However, no data will be extracted or posted. This flag is intended to be used for debugging and ensuring AWS is properly configured. Note that the `--test-aws-auth` and `--test-extraction` flags can be used together to execute the full AWS authentication and extraction process without actually posting any data to AWS.
 
 ## Masking Patient Data
 

--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ node src/cli.js --entries-filter --from-date YYYY-MM-DD --to-date YYY-MM-DD --ru
 
 ## Test Flight
 
-In order to test the extraction of ICARE data without posting to an ICAREdata AWS environment, use the `--test-flight` CLI option. For example:
+In order to test the extraction of ICARE data without posting to an ICAREdata AWS environment, use the `--test-extraction` CLI option. For example:
 
 ```bash
-node src/cli.js --test-flight
+node src/cli.js --test-extraction
 ```
 
 When this flag is used, the ICARE Extraction Client will execute full extraction using any extractors specified in the configuration file. However, no data will be sent to the AWS environment specified in the configuration file and no data will be output to a file. This flag is intended to be used for debugging and ensuring extraction is successful before posting any data.

--- a/src/app.js
+++ b/src/app.js
@@ -18,7 +18,7 @@ function getConfig(pathToConfig) {
   }
 }
 
-function checkInputAndConfig(config, fromDate, toDate, testFlight) {
+function checkInputAndConfig(config, fromDate, toDate, testExtraction) {
   // Check input args and needed config variables based on client being used
   const { patientIdCsvPath, awsConfig } = config;
 
@@ -38,7 +38,7 @@ function checkInputAndConfig(config, fromDate, toDate, testFlight) {
   }
 
   // AWS config is not required during test flight runs
-  if (!testFlight && !awsConfig) {
+  if (!testExtraction && !awsConfig) {
     throw new Error('awsConfig is required in config file');
   }
 }
@@ -78,14 +78,14 @@ function getEffectiveFromDate(fromDate, runLogger) {
 // TODO: There is a lot of overlap with this application and the mcode application,
 // esp. when it comes to the configuration file helpers, log-file helpers and effective-date parsers;
 // can improve later
-async function icareApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, debug, allEntries, testFlight) {
+async function icareApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, debug, allEntries, testExtraction) {
   try {
     if (debug) logger.level = 'debug';
-    if (testFlight) logger.info('test-flight will perform extraction but will not post any data');
+    if (testExtraction) logger.info('test-extraction will perform extraction but will not post any data');
     // Don't require a run-logs file if we are extracting all-entries. Only required when using --entries-filter.
     if (!allEntries) checkLogFile(pathToRunLogs);
     const config = getConfig(pathToConfig);
-    checkInputAndConfig(config, fromDate, toDate, testFlight);
+    checkInputAndConfig(config, fromDate, toDate, testExtraction);
 
     // Create and initialize client
     const icareClient = new Client(config);
@@ -97,7 +97,7 @@ async function icareApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, d
 
     // Get messaging client for messaging ICAREPlatform
     let messagingClient = null;
-    if (!testFlight) messagingClient = getMessagingClient(config);
+    if (!testExtraction) messagingClient = getMessagingClient(config);
 
     // Get RunInstanceLogger for recording new runs and inferring dates from previous runs
     const runLogger = allEntries ? null : new RunInstanceLogger(pathToRunLogs);
@@ -111,23 +111,23 @@ async function icareApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, d
     // Post the data using the messagingClient
     let successfulMessagePost = true;
     let messagingErrors = {};
-    if (!testFlight) {
+    if (!testExtraction) {
       logger.info(`Posting data for ${patientIds.length} patients`);
       ({ successfulMessagePost, messagingErrors } = await postExtractedData(messagingClient, extractedData));
     }
 
-    // Don't send emails if we're in a test-flight run
+    // Don't send emails if we're in a test-extraction run
     // If we have notification information, send an emailNotification
     const { notificationInfo } = config;
-    if (!testFlight && notificationInfo) {
+    if (!testExtraction && notificationInfo) {
       const notificationErrors = zipErrors(totalExtractionErrors, messagingErrors);
       await sendEmailNotification(notificationInfo, notificationErrors, debug);
     }
 
-    // Only log successful runs if we're in a real run, not a test-flight run
+    // Only log successful runs if we're in a real run, not a test-extraction run
     // A run is successful and should be logged when both extraction finishes without fatal errors
     // and messages are posted without fatal errors
-    if (!testFlight && !allEntries && effectiveFromDate) {
+    if (!testExtraction && !allEntries && effectiveFromDate) {
       const successCondition = successfulExtraction && successfulMessagePost;
       if (successCondition) {
         runLogger.addRun(effectiveFromDate, effectiveToDate);

--- a/src/app.js
+++ b/src/app.js
@@ -6,7 +6,7 @@ const { logger } = require('mcode-extraction-framework');
 const { sendEmailNotification, zipErrors } = require('mcode-extraction-framework');
 const { extractDataForPatients } = require('mcode-extraction-framework');
 const { RunInstanceLogger } = require('mcode-extraction-framework');
-const { getMessagingClient, postExtractedData } = require('./icareFhirMessaging');
+const { checkAwsAuthentication, getMessagingClient, postExtractedData } = require('./icareFhirMessaging');
 
 function getConfig(pathToConfig) {
   // Checks pathToConfig points to valid JSON file
@@ -78,14 +78,21 @@ function getEffectiveFromDate(fromDate, runLogger) {
 // TODO: There is a lot of overlap with this application and the mcode application,
 // esp. when it comes to the configuration file helpers, log-file helpers and effective-date parsers;
 // can improve later
-async function icareApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, debug, allEntries, testExtraction) {
+async function icareApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, debug, allEntries, testExtraction, testAwsAuth) {
   try {
     if (debug) logger.level = 'debug';
     if (testExtraction) logger.info('test-extraction will perform extraction but will not post any data');
+    if (testAwsAuth) logger.info('test-aws-auth will authenticate to AWS but will not extract or post any data');
     // Don't require a run-logs file if we are extracting all-entries. Only required when using --entries-filter.
     if (!allEntries) checkLogFile(pathToRunLogs);
     const config = getConfig(pathToConfig);
     checkInputAndConfig(config, fromDate, toDate, testExtraction);
+
+    if (testAwsAuth) {
+      // Check AWS configuration info and that messaging client is created and can send messages
+      await checkAwsAuthentication(config);
+      if (!testExtraction) return; // Since we don't want to extract any data, return
+    }
 
     // Create and initialize client
     const icareClient = new Client(config);

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,14 +15,14 @@ program
   .option('-r --run-log-filepath <path>', 'Specify relative path to log file of previous runs:', defaultPathToRunLogs)
   .option('-d, --debug', 'Output extra debugging information')
   .option('--test-extraction', 'Flag to test extraction without posting to AWS')
-  .option('--test-extraction', 'Flag to test extraction without posting to AWS')
+  .option('--test-aws-auth', 'Flag to test authentication to AWS without extracting any data')
   .parse(process.argv);
 
 const {
-  fromDate, toDate, configFilepath, runLogFilepath, debug, entriesFilter, testExtraction,
+  fromDate, toDate, configFilepath, runLogFilepath, debug, entriesFilter, testExtraction, testAwsAuth,
 } = program;
 
 // Flag to extract allEntries, or just to use to-from dates
 const allEntries = !entriesFilter;
 
-icareApp(ICARECSVClient, fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries, testExtraction);
+icareApp(ICARECSVClient, fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries, testExtraction, testAwsAuth);

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,14 +14,15 @@ program
   .option('-c --config-filepath <path>', 'Specify relative path to config to use:', defaultPathToConfig)
   .option('-r --run-log-filepath <path>', 'Specify relative path to log file of previous runs:', defaultPathToRunLogs)
   .option('-d, --debug', 'Output extra debugging information')
-  .option('--test-flight', 'Flag to test extraction without posting to AWS')
+  .option('--test-extraction', 'Flag to test extraction without posting to AWS')
+  .option('--test-extraction', 'Flag to test extraction without posting to AWS')
   .parse(process.argv);
 
 const {
-  fromDate, toDate, configFilepath, runLogFilepath, debug, entriesFilter, testFlight,
+  fromDate, toDate, configFilepath, runLogFilepath, debug, entriesFilter, testExtraction,
 } = program;
 
 // Flag to extract allEntries, or just to use to-from dates
 const allEntries = !entriesFilter;
 
-icareApp(ICARECSVClient, fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries, testFlight);
+icareApp(ICARECSVClient, fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries, testExtraction);

--- a/src/icareFhirMessaging.js
+++ b/src/icareFhirMessaging.js
@@ -38,7 +38,7 @@ async function checkAwsAuthentication(config) {
 
   // Ensure that the messagingClient can receive messages
   await checkMessagingClient(messagingClient);
-  logger.debug('AWS authenticated properly');
+  logger.info('AWS authenticated properly');
 }
 
 function makeUUIDFullUrl(uuid) {

--- a/src/icareFhirMessaging.js
+++ b/src/icareFhirMessaging.js
@@ -30,6 +30,17 @@ async function checkMessagingClient(messagingClient) {
   }
 }
 
+// This method is used to ensure AWS and FHIR messaging client are configured properly.
+// It is intended to be used with the --test-aws-auth flag. These functions are called separately during extraction.
+async function checkAwsAuthentication(config) {
+  // Ensure that we have the necessary aws info in the config file and that a MessagingClient can be made
+  const messagingClient = getMessagingClient(config);
+
+  // Ensure that the messagingClient can receive messages
+  await checkMessagingClient(messagingClient);
+  logger.debug('AWS authenticated properly');
+}
+
 function makeUUIDFullUrl(uuid) {
   // Utility for ensuring UUID's follow a valid URL specification as described by FHIR R4“
   return `urn:uuid:${uuid}`;
@@ -124,6 +135,7 @@ async function postExtractedData(messagingClient, bundledData) {
 }
 
 module.exports = {
+  checkAwsAuthentication,
   checkMessagingClient,
   getMessagingClient,
   postExtractedData,


### PR DESCRIPTION
This PR adds a new flag to the CLI `--test-aws-auth`. When using this flag alone, the app will not extractor post any data, but it will check that it can create a messaging client and can authorize using the configuration information provided in `awsConfig`. If either of these steps fails, an error is thrown and logged. This is done in 99a1f39.

I also renamed the `--test-flight` flag because I thought it was less clear what it was testing now that we have multiple flags. This is done in 63b75fd, if it's easier to see the separate diffs.

If you use both these flags together, the app will ensure that AWS is properly authenticated and will extract data but it will not post to AWS.