### PR TITLE
Loosen required fields for Patient CSV and mark missing required fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2763,9 +2763,9 @@
       }
     },
     "fecha": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
-      "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
+      "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
     },
     "fhir-crud-client": {
       "version": "1.2.2",
@@ -5528,8 +5528,8 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#4bf88aae6681d9c48e343afbca2c7499deea1d90",
-      "from": "git+https://github.com/mcode/mcode-extraction-framework.git",
+      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#cc13692f1b8b039bf6aa9684ce622da7e79822c9",
+      "from": "git+https://github.com/mcode/mcode-extraction-framework.git#develop",
       "requires": {
         "ajv": "^6.12.6",
         "antlr4": "4.8.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "fhir-messaging-client": "git+https://github.com/ICAREdata/fhir-messaging-client.git",
     "fhirpath": "^2.3.0",
     "lodash": "^4.17.19",
-    "mcode-extraction-framework": "git+https://github.com/mcode/mcode-extraction-framework.git",
+    "mcode-extraction-framework": "git+https://github.com/mcode/mcode-extraction-framework.git#develop",
     "moment": "^2.24.0",
     "nodemailer": "^6.4.11",
     "uuid": "^7.0.2"


### PR DESCRIPTION
This just updates the MEF version so that the Base ICARE client also relaxes the requirements in the patient CSV. It should be sufficient to use the same test cases as in the equivalent MEF PR ([here](https://github.com/mcode/mcode-extraction-framework/pull/103)).

Only needs one reviewer.