### PR TITLE
Adding troubleshooting guide for BOMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The extraction client has built-in handling of byte order markers for CSV files 
 cat -v <file.csv>
 ```
 
-If there is an unexpected symbol at the beginning of the file, then there is a byte order marker that needs to be removed.
+If there is an unexpected symbol at the beginning of the file, then there may be a byte order marker that needs to be removed.
 
 ## Developer Guide
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ If a `from-date` is provided as an option when running the ICARE Extraction Clie
 npm start -- --entries-filter --from-date <YYYY-MM-DD> --to-date <YYYY-MM-DD> --config-filepath <path>
 ```
 
+## Troubleshooting
+
+### Byte Order Markers in CSV Files
+
+The extraction client has built-in handling of byte order markers for CSV files in UTF-8 and UTF-16 encodings. When using CSV files in other encodings, if you experience unexpected errors be sure to check for a byte order marker at the beginning of the file. One way to check is to run the following command from the command line:
+
+```bash
+cat -v file.csv
+```
+
+If there is an unexpected symbol at the beginning of the file, then there is a byte order marker that needs to be removed.
+
 ## Developer Guide
 
 After making changes to any of the dependent libraries, including the [mCODE Extraction Framework](https://github.com/mcode/mcode-extraction-framework), you will need to run the following command ensure you have the updated dependencies:

--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ npm start -- --entries-filter --from-date <YYYY-MM-DD> --to-date <YYYY-MM-DD> --
 
 ### Byte Order Markers in CSV Files
 
-The extraction client has built-in handling of byte order markers for CSV files in UTF-8 and UTF-16 encodings. When using CSV files in other encodings, if you experience unexpected errors be sure to check for a byte order marker at the beginning of the file. One way to check is to run the following command from the command line:
+The extraction client has built-in handling of byte order markers for CSV files in UTF-8 and UTF-16LE encodings. When using CSV files in other encodings, if you experience unexpected errors be sure to check for a byte order marker at the beginning of the file. One way to check is to run the following command from the command line:
 
 ```bash
-cat -v file.csv
+cat -v <file.csv>
 ```
 
 If there is an unexpected symbol at the beginning of the file, then there is a byte order marker that needs to be removed.


### PR DESCRIPTION
# Summary
Added section to README informing users that byte order markers are handled for UTF-8 and UTF-16 but may cause issues in other encodings and how they can check for BOMs in their CSVs
# Testing guidance
Read the new section of the README and make sure it is all correct and that I didn't leave anything out