### PR TITLE
Merge for V1.0.1 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5529,7 +5529,7 @@
     },
     "mcode-extraction-framework": {
       "version": "git+https://github.com/mcode/mcode-extraction-framework.git#0aedf4bf44098cd2934482b26ba98641f1b9af03",
-      "from": "git+https://github.com/mcode/mcode-extraction-framework.git#develop",
+      "from": "git+https://github.com/mcode/mcode-extraction-framework.git",
       "requires": {
         "ajv": "^6.12.6",
         "antlr4": "4.8.0",
@@ -5578,16 +5578,6 @@
               "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
             }
           }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "nodemailer": {
-          "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.0.tgz",
-          "integrity": "sha512-ikSMDU1nZqpo2WUPE0wTTw/NGGImTkwpJKDIFPZT+YvvR9Sj+ze5wzu95JHkBMglQLoG2ITxU21WukCC/XsFkg=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5529,7 +5529,7 @@
     },
     "mcode-extraction-framework": {
       "version": "git+https://github.com/mcode/mcode-extraction-framework.git#4c007d85b127c1caa056c3b847922faa35c13e90",
-      "from": "git+https://github.com/mcode/mcode-extraction-framework.git",
+      "from": "git+https://github.com/mcode/mcode-extraction-framework.git#develop",
       "requires": {
         "ajv": "^6.12.6",
         "antlr4": "4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3123,9 +3123,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -5446,9 +5446,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -5528,7 +5528,7 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#4c007d85b127c1caa056c3b847922faa35c13e90",
+      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#0aedf4bf44098cd2934482b26ba98641f1b9af03",
       "from": "git+https://github.com/mcode/mcode-extraction-framework.git#develop",
       "requires": {
         "ajv": "^6.12.6",
@@ -5537,9 +5537,9 @@
         "csv-parse": "^4.8.8",
         "fhir-crud-client": "^1.2.2",
         "fhirpath": "2.1.5",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "moment": "^2.26.0",
-        "nodemailer": "^6.4.14",
+        "nodemailer": "^6.4.16",
         "sha.js": "^2.4.9",
         "winston": "^3.2.1"
       },
@@ -5578,6 +5578,11 @@
               "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
             }
           }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "nodemailer": {
           "version": "6.6.0",
@@ -5834,9 +5839,9 @@
       }
     },
     "nodemailer": {
-      "version": "6.4.11",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.11.tgz",
-      "integrity": "sha512-BVZBDi+aJV4O38rxsUh164Dk1NCqgh6Cm0rQSb9SK/DHGll/DrCMnycVDD7msJgZCnmVa8ASo8EZzR7jsgTukQ=="
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.0.tgz",
+      "integrity": "sha512-ikSMDU1nZqpo2WUPE0wTTw/NGGImTkwpJKDIFPZT+YvvR9Sj+ze5wzu95JHkBMglQLoG2ITxU21WukCC/XsFkg=="
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "base-icare-extraction-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base-icare-extraction-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "contributors": [
     "Julia Afeltra <jafeltra@mitre.org>",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "fhir-messaging-client": "git+https://github.com/ICAREdata/fhir-messaging-client.git",
     "fhirpath": "^2.3.0",
     "lodash": "^4.17.19",
-    "mcode-extraction-framework": "git+https://github.com/mcode/mcode-extraction-framework.git",
+    "mcode-extraction-framework": "git+https://github.com/mcode/mcode-extraction-framework.git#develop",
     "moment": "^2.24.0",
     "nodemailer": "^6.4.11",
     "uuid": "^7.0.2"

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "csv-parse": "^4.8.9",
     "fhir-messaging-client": "git+https://github.com/ICAREdata/fhir-messaging-client.git",
     "fhirpath": "^2.3.0",
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.21",
     "mcode-extraction-framework": "git+https://github.com/mcode/mcode-extraction-framework.git#develop",
     "moment": "^2.24.0",
-    "nodemailer": "^6.4.11",
+    "nodemailer": "^6.6.0",
     "uuid": "^7.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "fhir-messaging-client": "git+https://github.com/ICAREdata/fhir-messaging-client.git",
     "fhirpath": "^2.3.0",
     "lodash": "^4.17.21",
-    "mcode-extraction-framework": "git+https://github.com/mcode/mcode-extraction-framework.git#develop",
+    "mcode-extraction-framework": "git+https://github.com/mcode/mcode-extraction-framework.git",
     "moment": "^2.24.0",
     "nodemailer": "^6.6.0",
     "uuid": "^7.0.2"


### PR DESCRIPTION
This release updates the Base ICARE Extraction Client to use the latest version of the mCODE Extraction Framework, `v1.0.1`. The release notes for that version can be found [here](https://github.com/mcode/mcode-extraction-framework/releases/tag/v1.0.1).