### PR TITLE
Improve checking for default log file

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -45,7 +45,7 @@ function checkInputAndConfig(config, fromDate, toDate, testExtraction) {
 
 function checkLogFile(pathToLogs) {
   // If no custom log file was specified and no default log file exists, create one
-  if (pathToLogs === path.join('logs', 'run-logs.json') && !fs.existsSync(pathToLogs)) {
+  if (path.resolve(pathToLogs) === path.resolve(path.join('logs', 'run-logs.json')) && !fs.existsSync(pathToLogs)) {
     logger.info(`No log file found. Creating default log file at ${pathToLogs}`);
     if (!fs.existsSync('logs')) fs.mkdirSync('logs');
     fs.appendFileSync(pathToLogs, '[]');


### PR DESCRIPTION
# Summary
Previously, the check for the default log file used a strict equality looking for the value `/logs/run-logs.json`, but now the paths compared will be resolved to allow for different but functionally equivalent paths like `./logs/run-logs.json` or `../base-icare-extraction-client/logs/run-logs.json`, etc.
## New behavior
The `checkLogFile()` function in `app.js` now uses resolved paths to check for the default log file.
## Code changes
`checkLogFile()` in `app.js` updated with the change described above
# Testing guidance
To test this, starting with no default log file, the following commands should produce the same logs folder and file in the default location:
- `npm start -- -e -f 01-01-2019 -t 01-01-2021 -r ../base-icare-extraction-client/logs/run-logs.json`
- `npm start -- -e -f 01-01-2019 -t 01-01-2021`