### PR TITLE
Use MEF helper for parsing patient IDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2768,9 +2768,9 @@
       "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
     },
     "fhir-crud-client": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/fhir-crud-client/-/fhir-crud-client-1.2.2.tgz",
-      "integrity": "sha512-+nEd98agDAcXf9AYAo7cPddLlBL40OH54xLht+zBUjbjx02YM2rDNNHnGiZgZopSrYmLrBY6U3SZERkkiLjupQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/fhir-crud-client/-/fhir-crud-client-1.2.3.tgz",
+      "integrity": "sha512-eGuwO3YbzxW3i+7HA3oRWgOzX57rDKsptkT1nAKvGiPBFE+hSWMZulMiSOJ/SLLIaLQYBIwotB2O3viTbM/0aw==",
       "requires": {
         "axios": "^0.21.1",
         "lodash": "^4.17.15",
@@ -5528,7 +5528,7 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#0aedf4bf44098cd2934482b26ba98641f1b9af03",
+      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#40f75a51b9c9f6d0ade8f2c46b6a705cc0c7ab72",
       "from": "git+https://github.com/mcode/mcode-extraction-framework.git#develop",
       "requires": {
         "ajv": "^6.12.6",

--- a/src/app.js
+++ b/src/app.js
@@ -1,11 +1,9 @@
-const parse = require('csv-parse/lib/sync');
 const fs = require('fs');
 const path = require('path');
 const moment = require('moment');
-const { logger } = require('mcode-extraction-framework');
-const { sendEmailNotification, zipErrors } = require('mcode-extraction-framework');
-const { extractDataForPatients } = require('mcode-extraction-framework');
-const { RunInstanceLogger } = require('mcode-extraction-framework');
+const {
+  logger, sendEmailNotification, zipErrors, extractDataForPatients, RunInstanceLogger, parsePatientIds,
+} = require('mcode-extraction-framework');
 const { checkAwsAuthentication, getMessagingClient, postExtractedData } = require('./icareFhirMessaging');
 
 function getConfig(pathToConfig) {
@@ -99,8 +97,7 @@ async function icareApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, d
     await icareClient.init();
 
     // Parse CSV for list of patient mrns
-    const patientIdsCsvPath = path.resolve(config.patientIdCsvPath);
-    const patientIds = parse(fs.readFileSync(patientIdsCsvPath, 'utf8'), { columns: true, bom: true }).map((row) => row.mrn);
+    const patientIds = parsePatientIds(config.patientIdCsvPath);
 
     // Get messaging client for messaging ICAREPlatform
     let messagingClient = null;


### PR DESCRIPTION
# Summary

Depends on [mcode-extraction-framework pull #124](https://github.com/mcode/mcode-extraction-framework/pull/124). Dependency in package-lock will be updated once that PR is merged.

## New behavior

None

## Code changes

Use helper to parse patient CSVs instead of re-calling parse library function.

Also included all MEF imports in one statement lol 

# Testing guidance

Change branch of MEF dependency to from `develop` to `patient-csv-util` in `package.json`

Run extraction as normal, should still extract data for all patients listed in the MRNs CSV.