### PR TITLE
Moving process.exit from app to cli

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const program = require('commander');
+const { logger } = require('mcode-extraction-framework');
 const { ICARECSVClient } = require('./ICARECSVClient');
 const { icareApp } = require('./app');
 
@@ -25,4 +26,15 @@ const {
 // Flag to extract allEntries, or just to use to-from dates
 const allEntries = !entriesFilter;
 
-icareApp(ICARECSVClient, fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries, testExtraction, testAwsAuth);
+async function runApp() {
+  try {
+    await icareApp(ICARECSVClient, fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries, testExtraction, testAwsAuth);
+  } catch (e) {
+    if (debug) logger.level = 'debug';
+    logger.error(e.message);
+    logger.debug(e.stack);
+    process.exit(1);
+  }
+}
+
+runApp();


### PR DESCRIPTION
# Summary
Same functionality as described here: https://github.com/mcode/mcode-extraction-framework/pull/121 added to the ICARE client. `process.exit` is now called from the CLI rather than the app
# Testing guidance
- Ensure that all tests pass and the client still runs as expected
- Run the program with inputs that will throw an error, like `npm start -- -f 54849/382/3742` and make sure the error is still properly caught