### PR TITLE
Use RunInstanceLogger for log file functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5528,7 +5528,7 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#40f75a51b9c9f6d0ade8f2c46b6a705cc0c7ab72",
+      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#641b6bbf91d6be50efaf24ceb17b47fb5ca69a0f",
       "from": "git+https://github.com/mcode/mcode-extraction-framework.git#develop",
       "requires": {
         "ajv": "^6.12.6",

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,12 +1,9 @@
-const fs = require('fs');
 const rewire = require('rewire');
 const testConfig = require('./fixtures/test-config.json');
 
 const appUtils = rewire('../src/app.js');
 const checkInputAndConfig = appUtils.__get__('checkInputAndConfig');
-const checkLogFile = appUtils.__get__('checkLogFile');
 const getConfig = appUtils.__get__('getConfig');
-const getEffectiveFromDate = appUtils.__get__('getEffectiveFromDate');
 
 describe('appUtils', () => {
   describe('getConfig', () => {
@@ -46,55 +43,6 @@ describe('appUtils', () => {
     });
     it('should not throw error when all args are valid', () => {
       expect(() => checkInputAndConfig(testConfig, '2020-06-01', '2020-06-30', false)).not.toThrowError();
-    });
-  });
-
-  describe('checkLogFile', () => {
-    const fsSpy = jest.spyOn(fs, 'readFileSync');
-    it('should throw error when not provided a path', () => {
-      expect(() => checkLogFile()).toThrowError();
-    });
-
-    it('should throw error when path does not point to valid JSON', () => {
-      expect(() => checkLogFile('./bad-path')).toThrowError();
-    });
-
-    it('should throw error when log file is not an array', () => {
-      fsSpy.mockReturnValueOnce(Buffer.from('{}'));
-      expect(() => checkLogFile('path')).toThrowError('Log file needs to be an array.');
-      expect(fsSpy).toHaveBeenCalled();
-    });
-
-    it('should not throw error when log file is an array', () => {
-      fsSpy.mockReturnValueOnce(Buffer.from('[]'));
-      expect(() => checkLogFile('path')).not.toThrowError();
-      expect(fsSpy).toHaveBeenCalled();
-    });
-  });
-
-  describe('getEffectiveFromDate', () => {
-    const testDate = '2020-06-16';
-    const mockRunLogger = {
-      getMostRecentToDate: jest.fn(),
-      addRun: jest.fn(),
-    };
-
-    beforeEach(() => {
-      jest.resetAllMocks();
-    });
-
-    it('should return fromDate when valid', () => {
-      expect(getEffectiveFromDate(testDate)).toEqual(testDate);
-    });
-
-    it('should return most recent date from runLogger', () => {
-      mockRunLogger.getMostRecentToDate.mockReturnValue(testDate);
-      expect(getEffectiveFromDate(null, mockRunLogger)).toEqual(testDate);
-    });
-
-    it('should throw error when no recent date from runlogger', () => {
-      expect(() => getEffectiveFromDate(null, mockRunLogger)).toThrowError();
-      expect(mockRunLogger.getMostRecentToDate).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
# Summary
Removed `checkLogFile` and `getEffectiveFromDate` and changed `app.js` to use `RunInstanceLogger` for these functions.
## New behavior
The client should behave the same as before
## Code changes
 - `checkLogFile` and `getEffectiveFromDate` removed from `app.js`
 - `app.js` modified to use `RunInstanceLogger` for the previously mentioned functions
 - Tests for removed functions removed from `app.test.js`
# Testing guidance
- Ensure that the client behaves the same and all tests still pass