### PR TITLE
Moving config parsing from app to CLI

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,20 +1,8 @@
-const fs = require('fs');
-const path = require('path');
 const moment = require('moment');
 const {
   logger, sendEmailNotification, zipErrors, extractDataForPatients, RunInstanceLogger, parsePatientIds,
 } = require('mcode-extraction-framework');
 const { checkAwsAuthentication, getMessagingClient, postExtractedData } = require('./icareFhirMessaging');
-
-function getConfig(pathToConfig) {
-  // Checks pathToConfig points to valid JSON file
-  const fullPath = path.resolve(pathToConfig);
-  try {
-    return JSON.parse(fs.readFileSync(fullPath));
-  } catch (err) {
-    throw new Error(`The provided filepath to a configuration file ${pathToConfig}, full path ${fullPath} did not point to a valid JSON file.`);
-  }
-}
 
 function checkInputAndConfig(config, fromDate, toDate, testExtraction) {
   // Check input args and needed config variables based on client being used
@@ -44,11 +32,10 @@ function checkInputAndConfig(config, fromDate, toDate, testExtraction) {
 // TODO: There is a lot of overlap with this application and the mcode application,
 // esp. when it comes to the configuration file helpers, log-file helpers and effective-date parsers;
 // can improve later
-async function icareApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, debug, allEntries, testExtraction, testAwsAuth) {
+async function icareApp(Client, fromDate, toDate, config, pathToRunLogs, debug, allEntries, testExtraction, testAwsAuth) {
   if (debug) logger.level = 'debug';
   if (testExtraction) logger.info('test-extraction will perform extraction but will not post any data');
   if (testAwsAuth) logger.info('test-aws-auth will authenticate to AWS but will not extract or post any data');
-  const config = getConfig(pathToConfig);
   checkInputAndConfig(config, fromDate, toDate, testExtraction);
 
   if (testAwsAuth) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const program = require('commander');
-const { logger } = require('mcode-extraction-framework');
+const { logger, getConfig } = require('mcode-extraction-framework');
 const { ICARECSVClient } = require('./ICARECSVClient');
 const { icareApp } = require('./app');
 
@@ -28,7 +28,8 @@ const allEntries = !entriesFilter;
 
 async function runApp() {
   try {
-    await icareApp(ICARECSVClient, fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries, testExtraction, testAwsAuth);
+    const config = getConfig(configFilepath);
+    await icareApp(ICARECSVClient, fromDate, toDate, config, runLogFilepath, debug, allEntries, testExtraction, testAwsAuth);
   } catch (e) {
     if (debug) logger.level = 'debug';
     logger.error(e.message);

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -3,22 +3,8 @@ const testConfig = require('./fixtures/test-config.json');
 
 const appUtils = rewire('../src/app.js');
 const checkInputAndConfig = appUtils.__get__('checkInputAndConfig');
-const getConfig = appUtils.__get__('getConfig');
 
 describe('appUtils', () => {
-  describe('getConfig', () => {
-    const pathToConfig = 'test/fixtures/test-config.json';
-
-    it('should throw error when pathToConfig does not point to valid JSON file.', () => {
-      expect(() => getConfig()).toThrowError();
-    });
-
-    it('should return test config', () => {
-      const config = getConfig(pathToConfig);
-      expect(config).toEqual(testConfig);
-    });
-  });
-
   describe('checkInputAndConfig', () => {
     it('should throw error when fromDate is invalid.', () => {
       expect(() => checkInputAndConfig(testConfig, '2020-06-31')).toThrowError('-f/--from-date is not a valid date.');


### PR DESCRIPTION
# Summary
Rather than pass the config file path to `icareApp`, the config will now be parsed in the CLI and passed to the app as an object.
## New behavior
The client should behave as before
## Code changes
- Changed the `pathToConfig` argument of `icareApp` to `config` and removed config parsing from that file
- Added `getConfig()` (now imported from the MEF) call to `cli.js`, the result is then passed into `icareApp`
- Tests for `getConfig()` removed from `app.test.js` since we now import the function from MEF
# Testing guidance
- You will need to change the MEF dependency to `"mcode-extraction-framework": "git+https://github.com/mcode/mcode-extraction-framework.git#config-as-object"` in order to test this
- Make sure extraction still works as expected
- Make sure config parsing still works as expected (errors still thrown for bad paths to config, etc)