### PR TITLE
Readme update referencing new mask fields for Patient resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ When this flag is used, the ICARE Extraction Client will try to connect to and a
 ## Masking Patient Data
 
 Patient data can be masked within the extracted `Patient` resource. When masked, the value of the field will be replaced with a [Data Absent Reason extension](https://www.hl7.org/fhir/extension-data-absent-reason.html) with the code `masked`.
-Patient properties that can be masked are: `gender`, `mrn`, `name`, `address`, `birthDate`, `language`, `ethnicity`, `birthsex`, and `race`.
+Patient properties that can be masked are: `gender`, `mrn`, `name`, `address`, `birthDate`, `language`, `ethnicity`, `birthsex`, `race`, `telecom`, `multipleBirth`, `photo`, `contact`, `generalPractitioner`, `managingOrganization`, and `link`.
 To mask a property, provide an array of the properties to mask in the `constructorArgs` of the Patient extractor. For example, the following configuration can be used to mask `address` and `birthDate`:
 
 ```bash


### PR DESCRIPTION
# Summary
Simply updating the readme to reference new fields that are supported for masking on the patient resource. Will update the MEF dependency once the [Masking PR on the MEF repo](https://github.com/mcode/mcode-extraction-framework/pull/155) is approved.