### PR TITLE
dataDirectory and csv-parse passthrough options support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ More information on the data that should be provided in each CSV file can be fou
 After exporting your CSV files to the `data` directory, kickstart the creation of a configuration file by renaming the provided `csv.config.example.json` to `csv.config.json`. Then, ensure the following configuration parameters are properly set:
 
 1. `patientIdCsvPath` should provide a file path to a CSV file containing MRN's for relevant patients;
-2. For each extractor, `filePath:` should provide a file path to a CSV file containing that corresponding extractor's data;
-3. For the ClinicalInformationExtractor, `clinicalSiteID` should correspond to the researchId used by your clinical site in support of the ICAREdata trial;
-4. The `awsConfig` object needs to be updated to include the following fields with information that is sent separately by the ICAREdata team:
+2. `commonExtractorArgs.dataDirectory` should correspond to an absolute path to the dataDirectory containing all your exported CSV files;
+3. For each extractor, `fileName` should correspond to the file name this extractor should be reading from. Note: combining the `dataDirectory` above and `fileName` should resolve to a file on disk containing this corresponding extractor's data;
+4. For the ClinicalInformationExtractor, `clinicalSiteID` should correspond to the researchId used by your clinical site in support of the ICAREdata trial;
+5. The `awsConfig` object needs to be updated to include the following fields with information that is sent separately by the ICAREdata team:
    - A `baseURL` field that indicates the base URL of the server to post messages to.
    - A `clientId` field containing the client ID that is registered for the ICAREdata OAuth2 framework.
    - An `aud` field containing the audience parameter that is registered for the client in the ICAREdata OAuth2 framework.
@@ -61,6 +62,7 @@ After exporting your CSV files to the `data` directory, kickstart the creation o
      - Two fields - `pkcs12` and `pkcs12Pass` - where the former is a filepath to your locally saved P12 file and the latter is the password for opening that file, or;
      - A `jwk` field, containing a JWK-JSON object configured to contain the relevant private-key information.
 
+**Note**: Previous versions of the extraction client suggested using a `filePath` property for each extractor; while this property should still work without issue, the recommended approach is to use a common dataDirectory for all CSV files and to have each Extractor call out the name of the CSV file they need.
 
 For instructions on setting up an email notification trigger whenever an error is encountered in extraction, see the [Email Notification](#Email-Notification) section below.`
 
@@ -91,7 +93,7 @@ In order to send an email, users must specify the hostname or IP address of an S
 - `port`: `<number>` (Optional) The port to connect to (defaults to 587)
 - `to`: `<string[]>` Comma separated list or an array of recipients email addresses that will appear on the _To:_ field
 - `from`: `<string>` (Optional) The email address of the sender. All email addresses can be plain `'sender@server.com'` or formatted `'"Sender Name" sender@server.com'` (defaults to mcode-extraction-errors@mitre.org, which cannot receive reply emails)
-- `tlsRejectUnauthorized`: `<boolean>` (Optional) A boolean value to set the [node.js TLSSocket option](https://nodejs.org/api/tls.html#tls_class_tls_tlssocket) for rejecting any unauthorized connections, `tls.rejectUnauthorized`.  (defaults to `true`)
+- `tlsRejectUnauthorized`: `<boolean>` (Optional) A boolean value to set the [node.js TLSSocket option](https://nodejs.org/api/tls.html#tls_class_tls_tlssocket) for rejecting any unauthorized connections, `tls.rejectUnauthorized`. (defaults to `true`)
 
 An example of this object can be found in [`config/csv.config.example.json`](config/csv.config.example.json).
 
@@ -136,7 +138,7 @@ To mask a property, provide an array of the properties to mask in the `construct
   "label": "patient",
   "type": "CSVPatientExtractor",
   "constructorArgs": {
-    "filePath": "./data/patient-information.csv"
+    "fileName": "patient-information.csv"
     "mask": ["address", "birthDate"]
   }
 }
@@ -144,16 +146,16 @@ To mask a property, provide an array of the properties to mask in the `construct
 
 Alternatively, providing a string with a value of `all` in the `constructorArgs` of the Patient extractor will mask all of the supported properties listed above. The following configuration can be used to mask all properties of the `Patient` resource, rather than listing each individual property:
 
- ```bash
- {
-   "label": "patient",
-   "type": "CSVPatientExtractor",
-   "constructorArgs": {
-     "filePath": "./data/patient-information.csv"
-     "mask": "all"
-   }
- }
- ```
+```bash
+{
+  "label": "patient",
+  "type": "CSVPatientExtractor",
+  "constructorArgs": {
+    "fileName": "patient-information.csv"
+    "mask": "all"
+  }
+}
+```
 
 ## Extraction Date Range
 
@@ -183,6 +185,23 @@ cat -v <file.csv>
 
 If there is an unexpected symbol at the beginning of the file, then there may be a byte order marker that needs to be removed.
 
+#### Troubleshooting Additional Errors
+
+The extraction client uses the node `csv-parse` library to parse specified CSV files. [Parsing options for the `csv-parse` library](https://csv.js.org/parse/options/) can be included in the configuration file within the `commonExtractorArgs.csvParse.options` section. For example, the following configuration will pass the `to` option to the `csv-parse` module, causing the extraction client to only read CSV files up to the specified line number:
+
+```
+"commonExtractorArgs": {
+    "dataDirectory": "/Users/*****/Documents/dataDirectory",
+    "csvParse": {
+      "options": {
+        "to": 3
+      }
+    }
+  },
+```
+
+**Note:** The extraction client enables the `bom`, `skip_empty_lines`, and `skip_lines_with_empty_values` options by default, including these options in the configuration file will cause these default options to be overwritten.
+
 ## Developer Guide
 
 After making changes to any of the dependent libraries, including the [mCODE Extraction Framework](https://github.com/mcode/mcode-extraction-framework), you will need to run the following command ensure you have the updated dependencies:
@@ -196,7 +215,6 @@ If you need to update the version of a package (e.g. update `mcode-extraction-fr
 ```bash
 npm upgrade <pkg-name>
 ```
-
 
 ## License
 

--- a/config/csv.config.example.json
+++ b/config/csv.config.example.json
@@ -1,6 +1,8 @@
 {
   "patientIdCsvPath": "./data/patient-mrns.csv",
-  "commonExtractorArgs": {},
+  "commonExtractorArgs": {
+    "dataDirectory": "Users/YourAccount/absolute/path/to/data/directory"
+  },
   "notificationInfo": {
     "host": "smtp.example.com",
     "port": 587,
@@ -16,28 +18,28 @@
       "label": "patient",
       "type": "CSVPatientExtractor",
       "constructorArgs": {
-        "filePath": "./data/patient-information.csv"
+        "fileName": "patient-information.csv"
       }
     },
     {
       "label": "condition",
       "type": "CSVConditionExtractor",
       "constructorArgs": {
-        "filePath": "./data/condition-information.csv"
+        "fileName": "condition-information.csv"
       }
     },
     {
       "label": "cancerDiseaseStatus",
       "type": "CSVCancerDiseaseStatusExtractor",
       "constructorArgs": {
-        "filePath": "./data/cancer-disease-status-information.csv"
+        "fileName": "cancer-disease-status-information.csv"
       }
     },
     {
       "label": "clinicalTrialInformation",
       "type": "CSVClinicalTrialInformationExtractor",
       "constructorArgs": {
-        "filePath": "./data/clinical-trial-information.csv",
+        "fileName": "clinical-trial-information.csv",
         "clinicalSiteID": "example-site-id"
       }
     },
@@ -45,7 +47,7 @@
       "label": "treatmentPlanChange",
       "type": "CSVTreatmentPlanChangeExtractor",
       "constructorArgs": {
-        "filePath": "./data/treatment-plan-change-information.csv"
+        "fileName": "treatment-plan-change-information.csv"
       }
     }
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -2773,8 +2773,8 @@
       }
     },
     "fhir-messaging-client": {
-      "version": "git+https://github.com/ICAREdata/fhir-messaging-client.git#55989b2e49810de9210540dd9697c4fc1d73e89f",
-      "from": "git+https://github.com/ICAREdata/fhir-messaging-client.git#develop",
+      "version": "git+ssh://git@github.com/ICAREdata/fhir-messaging-client.git#55989b2e49810de9210540dd9697c4fc1d73e89f",
+      "from": "fhir-messaging-client@git+https://github.com/ICAREdata/fhir-messaging-client.git#develop",
       "requires": {
         "acorn": "^7.1.1",
         "axios": "^0.21.1",
@@ -5525,8 +5525,8 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#5af50681b75cc49c45565271a6915bed490def39",
-      "from": "git+https://github.com/mcode/mcode-extraction-framework.git#develop",
+      "version": "git+ssh://git@github.com/mcode/mcode-extraction-framework.git#5af50681b75cc49c45565271a6915bed490def39",
+      "from": "mcode-extraction-framework@git+https://github.com/mcode/mcode-extraction-framework.git#develop",
       "requires": {
         "ajv": "^6.12.6",
         "antlr4": "4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2773,8 +2773,8 @@
       }
     },
     "fhir-messaging-client": {
-      "version": "git+ssh://git@github.com/ICAREdata/fhir-messaging-client.git#55989b2e49810de9210540dd9697c4fc1d73e89f",
-      "from": "fhir-messaging-client@git+https://github.com/ICAREdata/fhir-messaging-client.git#develop",
+      "version": "git+https://github.com/ICAREdata/fhir-messaging-client.git#55989b2e49810de9210540dd9697c4fc1d73e89f",
+      "from": "git+https://github.com/ICAREdata/fhir-messaging-client.git#develop",
       "requires": {
         "acorn": "^7.1.1",
         "axios": "^0.21.1",
@@ -5525,8 +5525,8 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+ssh://git@github.com/mcode/mcode-extraction-framework.git#5af50681b75cc49c45565271a6915bed490def39",
-      "from": "mcode-extraction-framework@git+https://github.com/mcode/mcode-extraction-framework.git#develop",
+      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#5af50681b75cc49c45565271a6915bed490def39",
+      "from": "git+https://github.com/mcode/mcode-extraction-framework.git#develop",
       "requires": {
         "ajv": "^6.12.6",
         "antlr4": "4.8.0",

--- a/src/app.js
+++ b/src/app.js
@@ -1,8 +1,17 @@
 const moment = require('moment');
 const {
-  logger, sendEmailNotification, zipErrors, extractDataForPatients, RunInstanceLogger, parsePatientIds,
+  logger,
+  sendEmailNotification,
+  zipErrors,
+  extractDataForPatients,
+  RunInstanceLogger,
+  parsePatientIds,
 } = require('mcode-extraction-framework');
-const { checkAwsAuthentication, getMessagingClient, postExtractedData } = require('./icareFhirMessaging');
+const {
+  checkAwsAuthentication,
+  getMessagingClient,
+  postExtractedData,
+} = require('./icareFhirMessaging');
 
 function checkInputAndConfig(config, fromDate, toDate, testExtraction) {
   // Check input args and needed config variables based on client being used
@@ -32,10 +41,26 @@ function checkInputAndConfig(config, fromDate, toDate, testExtraction) {
 // TODO: There is a lot of overlap with this application and the mcode application,
 // esp. when it comes to the configuration file helpers, log-file helpers and effective-date parsers;
 // can improve later
-async function icareApp(Client, fromDate, toDate, config, pathToRunLogs, debug, allEntries, testExtraction, testAwsAuth) {
+async function icareApp(
+  Client,
+  fromDate,
+  toDate,
+  config,
+  pathToRunLogs,
+  debug,
+  allEntries,
+  testExtraction,
+  testAwsAuth
+) {
   if (debug) logger.level = 'debug';
-  if (testExtraction) logger.info('test-extraction will perform extraction but will not post any data');
-  if (testAwsAuth) logger.info('test-aws-auth will authenticate to AWS but will not extract or post any data');
+  if (testExtraction)
+    logger.info(
+      'test-extraction will perform extraction but will not post any data'
+    );
+  if (testAwsAuth)
+    logger.info(
+      'test-aws-auth will authenticate to AWS but will not extract or post any data'
+    );
   checkInputAndConfig(config, fromDate, toDate, testExtraction);
 
   if (testAwsAuth) {
@@ -49,7 +74,19 @@ async function icareApp(Client, fromDate, toDate, config, pathToRunLogs, debug, 
   await icareClient.init();
 
   // Parse CSV for list of patient mrns
-  const patientIds = parsePatientIds(config.patientIdCsvPath);
+  const dataDirectory =
+    config.commonExtractorArgs && config.commonExtractorArgs.dataDirectory;
+  const parserOptions =
+    config.commonExtractorArgs &&
+    config.commonExtractorArgs.csvParse &&
+    config.commonExtractorArgs.csvParse.options
+      ? config.commonExtractorArgs.csvParse.options
+      : {};
+  const patientIds = parsePatientIds(
+    config.patientIdCsvPath,
+    dataDirectory,
+    parserOptions
+  );
 
   // Get messaging client for messaging ICAREPlatform
   let messagingClient = null;
@@ -57,26 +94,40 @@ async function icareApp(Client, fromDate, toDate, config, pathToRunLogs, debug, 
 
   // Get RunInstanceLogger for recording new runs and inferring dates from previous runs
   const runLogger = allEntries ? null : new RunInstanceLogger(pathToRunLogs);
-  const effectiveFromDate = allEntries ? null : runLogger.getEffectiveFromDate(fromDate, runLogger);
+  const effectiveFromDate = allEntries
+    ? null
+    : runLogger.getEffectiveFromDate(fromDate, runLogger);
   const effectiveToDate = allEntries ? null : toDate;
 
   // Extract the data
   logger.info(`Extracting data for ${patientIds.length} patients`);
-  const { extractedData, successfulExtraction, totalExtractionErrors } = await extractDataForPatients(patientIds, icareClient, effectiveFromDate, effectiveToDate);
+  const { extractedData, successfulExtraction, totalExtractionErrors } =
+    await extractDataForPatients(
+      patientIds,
+      icareClient,
+      effectiveFromDate,
+      effectiveToDate
+    );
 
   // Post the data using the messagingClient
   let successfulMessagePost = true;
   let messagingErrors = {};
   if (!testExtraction) {
     logger.info(`Posting data for ${patientIds.length} patients`);
-    ({ successfulMessagePost, messagingErrors } = await postExtractedData(messagingClient, extractedData));
+    ({ successfulMessagePost, messagingErrors } = await postExtractedData(
+      messagingClient,
+      extractedData
+    ));
   }
 
   // Don't send emails if we're in a test-extraction run
   // If we have notification information, send an emailNotification
   const { notificationInfo } = config;
   if (!testExtraction && notificationInfo) {
-    const notificationErrors = zipErrors(totalExtractionErrors, messagingErrors);
+    const notificationErrors = zipErrors(
+      totalExtractionErrors,
+      messagingErrors
+    );
     await sendEmailNotification(notificationInfo, notificationErrors, debug);
   }
 


### PR DESCRIPTION
This PR adds support for the `dataDirectory`/`fileName` motif in the ICARE Extraction Client, and also adds support for passthrough `csv-parse` options in the common extractor args. 

Passthrough csv-parse options can be tested by including the following in the `commonExtractorArgs` section of your config, which will instruct the client to only extract resources for the first two patients included in the patient MRNs file:
```
"csvParse": {
   "options": {
      "to": 2
   }
 }
```

**Note: I would recommend using the `--test-extraction` flag while testing this so as to not send thing to the database unnecessarily.**