### PR TITLE
Adding extractor dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5474,6 +5474,11 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "safe-stable-stringify": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
+          "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
         }
       }
     },
@@ -5525,7 +5530,7 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#5af50681b75cc49c45565271a6915bed490def39",
+      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#e786e2972673e566931b1056fa43d2dc25af8332",
       "from": "git+https://github.com/mcode/mcode-extraction-framework.git#develop",
       "requires": {
         "ajv": "^6.12.6",
@@ -6562,9 +6567,9 @@
       }
     },
     "safe-stable-stringify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
-      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -7697,9 +7702,9 @@
       "dev": true
     },
     "winston": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.4.0.tgz",
-      "integrity": "sha512-FqilVj+5HKwCfIHQzMxrrd5tBIH10JTS3koFGbLVWBODjiIYq7zir08rFyBT4rrTYG/eaTqDcfSIbcjSM78YSw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.5.1.tgz",
+      "integrity": "sha512-tbRtVy+vsSSCLcZq/8nXZaOie/S2tPXPFt4be/Q3vI/WtYwm7rrwidxVw2GRa38FIXcJ1kUM6MOZ9Jmnk3F3UA==",
       "requires": {
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
@@ -7707,6 +7712,7 @@
         "logform": "^2.3.2",
         "one-time": "^1.0.0",
         "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
         "winston-transport": "^4.4.2"
@@ -7730,13 +7736,13 @@
       }
     },
     "winston-transport": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.2.tgz",
-      "integrity": "sha512-9jmhltAr5ygt5usgUTQbEiw/7RYXpyUbEAFRCSicIacpUzPkrnQsQZSPGEI12aLK9Jth4zNcYJx3Cvznwrl8pw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
+      "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
       "requires": {
         "logform": "^2.3.2",
-        "readable-stream": "^3.4.0",
-        "triple-beam": "^1.2.0"
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
       },
       "dependencies": {
         "readable-stream": {

--- a/src/ICARECSVClient.js
+++ b/src/ICARECSVClient.js
@@ -5,6 +5,7 @@ const {
   CSVClinicalTrialInformationExtractor,
   CSVPatientExtractor,
   CSVTreatmentPlanChangeExtractor,
+  sortExtractors,
 } = require('mcode-extraction-framework');
 const { generateNewMessageBundle } = require('./icareFhirMessaging');
 
@@ -20,6 +21,17 @@ class ICARECSVClient extends BaseClient {
     );
     // Store the extractors defined by the configuration file as local state
     this.extractorConfig = extractors;
+    // Define information about the order and dependencies of extractors
+    const dependencyInfo = [
+      { type: 'CSVPatientExtractor', dependencies: [] },
+      { type: 'CSVConditionExtractor', dependencies: ['CSVPatientExtractor'] },
+      { type: 'CSVCancerDiseaseStatusExtractor', dependencies: ['CSVPatientExtractor'] },
+      { type: 'CSVClinicalTrialInformationExtractor', dependencies: ['CSVPatientExtractor'] },
+      { type: 'CSVTreatmentPlanChangeExtractor', dependencies: ['CSVPatientExtractor'] },
+      { type: 'CSVStagingExtractor', dependencies: ['CSVPatientExtractor'] },
+    ];
+    // Sort extractors based on order and dependencies
+    this.extractorConfig = sortExtractors(this.extractorConfig, dependencyInfo);
     this.commonExtractorArgs = {
       implementation: 'icare',
       ...commonExtractorArgs,

--- a/test/ICARECSVClient.test.js
+++ b/test/ICARECSVClient.test.js
@@ -19,6 +19,14 @@ const testConfig = {
         filePath: path.join(__dirname, './fixtures/csv/example-condition.csv'),
       },
     },
+    {
+      label: 'patient',
+      type: 'CSVPatientExtractor',
+      constructorArgs: {
+        // This CSV path doesn't point at actual data, but a valid file with valid columns is needed to avoid CSV parser and CSV validation errors
+        filePath: path.join(__dirname, './fixtures/csv/example-patient.csv'),
+      },
+    },
   ],
 };
 

--- a/test/fixtures/csv/example-patient.csv
+++ b/test/fixtures/csv/example-patient.csv
@@ -1,0 +1,2 @@
+mrn,familyName,givenName,gender,birthsex,dateOfBirth,race,ethnicity,language,addressLine,city,state,zip
+example,values,a,b,c,d,e,f,g,h,i,j,k


### PR DESCRIPTION
# Summary
Adds the extractor dependency functionality from the MEF
## New behavior
Extractors can now be put in any order in the config file and will be sorted upon starting the client. Additionally an error will be thrown before extraction if any necessary extractors are missing. For the base ICARE use case this means the patient extractor will get sorted to be first and an error will be thrown if the patient extractor is missing since all other extractors depend on it.
## Code changes
- `ICARECSVClient.js` now calls the `sortExtractors()` function to check for missing dependencies and correctly order the extractors
- `ICARECSVClient.test.js` updated to work with the above changes, which required adding a new fixture as well
# Testing guidance
- Make sure that all tests pass
- Put the patient extractor at the bottom of your config and run the client (you can use `--test-extraction` to avoid posting data) and see that it still runs properly
- Remove the patient extractor from your config and see that the proper error is thrown