### PR TITLE
Adding post-extraction mapping and importing extractor list from MEF

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @julianxcarter @dmendelowitz @dtphelan1
+*   @dmendelowitz

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ node_modules/
 output/
 logs/
 *.p12
-config/*.json
+config/*
 !config/csv.config.example.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1207,11 +1207,6 @@
         "color-convert": "^1.9.0"
       }
     },
-    "antlr4": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.9.3.tgz",
-      "integrity": "sha512-qNy2odgsa0skmNMCuxzXhM4M8J1YDaPv3TI+vCdnOAanu0N982wBrSqziDKRDctEZLZy9VffqIZXc0UGjjSP/g=="
-    },
     "anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -2903,11 +2898,11 @@
       }
     },
     "fhir-mapper": {
-      "version": "git+https://github.com/standardhealth/fhir-mapper.git#f44bb79d2e4f2da0b3d825150b823006af251fda",
-      "from": "git+https://github.com/standardhealth/fhir-mapper.git",
+      "version": "git+https://github.com/standardhealth/fhir-mapper.git#531dcdb9d4673b14aa4fafe8eccfcdeaa1dd370e",
+      "from": "git+https://github.com/standardhealth/fhir-mapper.git#old-fhirpath",
       "requires": {
         "crypto": "^1.0.1",
-        "fhirpath": "3.8.1",
+        "fhirpath": "^0.10.3",
         "lodash": "^4.17.21"
       },
       "dependencies": {
@@ -2917,15 +2912,20 @@
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "fhirpath": {
-          "version": "3.8.1",
-          "resolved": "https://registry.npmjs.org/fhirpath/-/fhirpath-3.8.1.tgz",
-          "integrity": "sha512-476ZFG1dvYj0ynlSc2+x22PnMaQOeEmeZb/U1xCkGkMtosatuQXdTnNuzMnAqidGijfon7pa9eBBPLOzrcfOEw==",
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/fhirpath/-/fhirpath-0.10.3.tgz",
+          "integrity": "sha512-QxASSupObeYe8IAfX/qbSJoU57iitln8sN3W716G4gk6NJcLcbDLuiINibPqQ1MyugUEpUH/trl8Kb9i/l3Mhw==",
           "requires": {
-            "@lhncbc/ucum-lhc": "^4.1.3",
-            "antlr4": "~4.9.3",
+            "antlr4": "^4.7.1",
             "commander": "^2.18.0",
-            "date-fns": "^1.30.1",
-            "js-yaml": "^3.13.1"
+            "js-yaml": "^3.12.0"
+          },
+          "dependencies": {
+            "antlr4": {
+              "version": "4.8.0",
+              "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
+              "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
+            }
           }
         }
       }
@@ -5782,7 +5782,7 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#862193c6df678296572060a4b326062fdd6e66f7",
+      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#14281b5fe13e14d3dc02af9227f06873bee7b503",
       "from": "git+https://github.com/mcode/mcode-extraction-framework.git#export-extractor-list",
       "requires": {
         "ajv": "^6.12.6",
@@ -5791,7 +5791,7 @@
         "commander": "^6.2.0",
         "csv-parse": "^4.8.8",
         "fhir-crud-client": "^1.2.2",
-        "fhir-mapper": "git+https://github.com/standardhealth/fhir-mapper.git",
+        "fhir-mapper": "git+https://github.com/standardhealth/fhir-mapper.git#old-fhirpath",
         "fhirpath": "2.1.5",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -382,9 +382,9 @@
       }
     },
     "@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="
     },
     "@dabh/diagnostics": {
       "version": "2.0.3",
@@ -1104,9 +1104,9 @@
       "dev": true
     },
     "@types/triple-beam": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.3.tgz",
-      "integrity": "sha512-6tOUG+nVHn0cJbVp25JFayS5UE6+xlbcNF9Lo9mU7U0zk3zeUShZied4YEQZjy1JBF043FSkdXw8YkUJuVtB5g=="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
     },
     "@types/yargs": {
       "version": "15.0.15",
@@ -1208,9 +1208,9 @@
       }
     },
     "antlr4": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
-      "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.9.3.tgz",
+      "integrity": "sha512-qNy2odgsa0skmNMCuxzXhM4M8J1YDaPv3TI+vCdnOAanu0N982wBrSqziDKRDctEZLZy9VffqIZXc0UGjjSP/g=="
     },
     "anymatch": {
       "version": "3.1.3",
@@ -1313,9 +1313,9 @@
       "dev": true
     },
     "async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1941,6 +1941,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
     },
     "cssom": {
       "version": "0.4.4",
@@ -2895,6 +2900,34 @@
         "axios": "^0.21.1",
         "lodash": "^4.17.15",
         "url-join": "^4.0.1"
+      }
+    },
+    "fhir-mapper": {
+      "version": "git+https://github.com/standardhealth/fhir-mapper.git#f44bb79d2e4f2da0b3d825150b823006af251fda",
+      "from": "git+https://github.com/standardhealth/fhir-mapper.git",
+      "requires": {
+        "crypto": "^1.0.1",
+        "fhirpath": "3.8.1",
+        "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "fhirpath": {
+          "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/fhirpath/-/fhirpath-3.8.1.tgz",
+          "integrity": "sha512-476ZFG1dvYj0ynlSc2+x22PnMaQOeEmeZb/U1xCkGkMtosatuQXdTnNuzMnAqidGijfon7pa9eBBPLOzrcfOEw==",
+          "requires": {
+            "@lhncbc/ucum-lhc": "^4.1.3",
+            "antlr4": "~4.9.3",
+            "commander": "^2.18.0",
+            "date-fns": "^1.30.1",
+            "js-yaml": "^3.13.1"
+          }
+        }
       }
     },
     "fhir-messaging-client": {
@@ -5680,11 +5713,11 @@
       "dev": true
     },
     "logform": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.5.1.tgz",
-      "integrity": "sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+      "integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
       "requires": {
-        "@colors/colors": "1.5.0",
+        "@colors/colors": "1.6.0",
         "@types/triple-beam": "^1.3.2",
         "fecha": "^4.2.0",
         "ms": "^2.1.1",
@@ -5749,8 +5782,8 @@
       }
     },
     "mcode-extraction-framework": {
-      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#9e9659494a15b19e64f3331e8c95513544e2f44a",
-      "from": "git+https://github.com/mcode/mcode-extraction-framework.git",
+      "version": "git+https://github.com/mcode/mcode-extraction-framework.git#862193c6df678296572060a4b326062fdd6e66f7",
+      "from": "git+https://github.com/mcode/mcode-extraction-framework.git#export-extractor-list",
       "requires": {
         "ajv": "^6.12.6",
         "antlr4": "4.8.0",
@@ -5758,6 +5791,7 @@
         "commander": "^6.2.0",
         "csv-parse": "^4.8.8",
         "fhir-crud-client": "^1.2.2",
+        "fhir-mapper": "git+https://github.com/standardhealth/fhir-mapper.git",
         "fhirpath": "2.1.5",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -5765,6 +5799,11 @@
         "winston": "^3.2.1"
       },
       "dependencies": {
+        "antlr4": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
+          "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
+        },
         "commander": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -5782,6 +5821,11 @@
             "js-yaml": "^3.13.1"
           },
           "dependencies": {
+            "antlr4": {
+              "version": "4.8.0",
+              "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
+              "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
+            },
             "commander": {
               "version": "2.20.3",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -8086,11 +8130,11 @@
       }
     },
     "winston": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
-      "integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
+      "integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
       "requires": {
-        "@colors/colors": "1.5.0",
+        "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
@@ -8121,9 +8165,9 @@
       }
     },
     "winston-transport": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
-      "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.6.0.tgz",
+      "integrity": "sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==",
       "requires": {
         "logform": "^2.3.2",
         "readable-stream": "^3.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1208,9 +1208,9 @@
       }
     },
     "antlr4": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
-      "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.9.3.tgz",
+      "integrity": "sha512-qNy2odgsa0skmNMCuxzXhM4M8J1YDaPv3TI+vCdnOAanu0N982wBrSqziDKRDctEZLZy9VffqIZXc0UGjjSP/g=="
     },
     "anymatch": {
       "version": "3.1.3",
@@ -2922,17 +2922,10 @@
           "integrity": "sha512-476ZFG1dvYj0ynlSc2+x22PnMaQOeEmeZb/U1xCkGkMtosatuQXdTnNuzMnAqidGijfon7pa9eBBPLOzrcfOEw==",
           "requires": {
             "@lhncbc/ucum-lhc": "^4.1.3",
-            "antlr4": "4.8.0",
+            "antlr4": "~4.9.3",
             "commander": "^2.18.0",
             "date-fns": "^1.30.1",
             "js-yaml": "^3.13.1"
-          },
-          "dependencies": {
-            "antlr4": {
-              "version": "4.8.0",
-              "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
-              "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
-            }
           }
         }
       }
@@ -2965,7 +2958,7 @@
       "integrity": "sha512-iRg6UYk+tkamRBiOVmXjxjgIfoqtD7GeSk+SCPPiYX7S3vKd79MFuaQAHN8FBLGo//IKDosiOvL0llU1BSwx8Q==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "antlr4": "4.8.0",
+        "antlr4": "^4.7.1",
         "commander": "^2.18.0",
         "date-fns": "^1.30.1",
         "js-yaml": "^3.13.1"
@@ -5822,7 +5815,7 @@
           "integrity": "sha512-FIVNp0NrIhEcnwHCaQy6Wj4vM08RNeTs471MpCTEU6eFJPjSe9YGy6HhCAbcOzplwfL1SynMmLEWoTpDBOLRtA==",
           "requires": {
             "@lhncbc/ucum-lhc": "^4.1.3",
-            "antlr4": "4.8.0",
+            "antlr4": "^4.7.1",
             "commander": "^2.18.0",
             "date-fns": "^1.30.1",
             "js-yaml": "^3.13.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1208,9 +1208,9 @@
       }
     },
     "antlr4": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.9.3.tgz",
-      "integrity": "sha512-qNy2odgsa0skmNMCuxzXhM4M8J1YDaPv3TI+vCdnOAanu0N982wBrSqziDKRDctEZLZy9VffqIZXc0UGjjSP/g=="
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
+      "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
     },
     "anymatch": {
       "version": "3.1.3",
@@ -2922,10 +2922,17 @@
           "integrity": "sha512-476ZFG1dvYj0ynlSc2+x22PnMaQOeEmeZb/U1xCkGkMtosatuQXdTnNuzMnAqidGijfon7pa9eBBPLOzrcfOEw==",
           "requires": {
             "@lhncbc/ucum-lhc": "^4.1.3",
-            "antlr4": "~4.9.3",
+            "antlr4": "4.8.0",
             "commander": "^2.18.0",
             "date-fns": "^1.30.1",
             "js-yaml": "^3.13.1"
+          },
+          "dependencies": {
+            "antlr4": {
+              "version": "4.8.0",
+              "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
+              "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
+            }
           }
         }
       }
@@ -2958,7 +2965,7 @@
       "integrity": "sha512-iRg6UYk+tkamRBiOVmXjxjgIfoqtD7GeSk+SCPPiYX7S3vKd79MFuaQAHN8FBLGo//IKDosiOvL0llU1BSwx8Q==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "antlr4": "^4.7.1",
+        "antlr4": "4.8.0",
         "commander": "^2.18.0",
         "date-fns": "^1.30.1",
         "js-yaml": "^3.13.1"
@@ -5815,7 +5822,7 @@
           "integrity": "sha512-FIVNp0NrIhEcnwHCaQy6Wj4vM08RNeTs471MpCTEU6eFJPjSe9YGy6HhCAbcOzplwfL1SynMmLEWoTpDBOLRtA==",
           "requires": {
             "@lhncbc/ucum-lhc": "^4.1.3",
-            "antlr4": "^4.7.1",
+            "antlr4": "4.8.0",
             "commander": "^2.18.0",
             "date-fns": "^1.30.1",
             "js-yaml": "^3.13.1"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "commander": "^4.1.1",
     "cross-env": "^7.0.1",
     "csv-parse": "^4.8.9",
-    "fhir-mapper": "git+https://github.com/standardhealth/fhir-mapper.git",
+    "fhir-mapper": "git+https://github.com/standardhealth/fhir-mapper.git#old-fhirpath",
     "fhir-messaging-client": "git+https://github.com/ICAREdata/fhir-messaging-client.git",
     "fhirpath": "^2.3.0",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "commander": "^4.1.1",
     "cross-env": "^7.0.1",
     "csv-parse": "^4.8.9",
+    "fhir-mapper": "git+https://github.com/standardhealth/fhir-mapper.git",
     "fhir-messaging-client": "git+https://github.com/ICAREdata/fhir-messaging-client.git",
     "fhirpath": "^2.3.0",
     "lodash": "^4.17.21",
-    "mcode-extraction-framework": "git+https://github.com/mcode/mcode-extraction-framework.git",
+    "mcode-extraction-framework": "git+https://github.com/mcode/mcode-extraction-framework.git#export-extractor-list",
     "moment": "^2.29.4",
     "nodemailer": "^6.7.2",
     "uuid": "^7.0.2"

--- a/src/ICARECSVClient.js
+++ b/src/ICARECSVClient.js
@@ -1,58 +1,12 @@
-const {
-  BaseClient,
-  CSVAdverseEventExtractor,
-  CSVCancerDiseaseStatusExtractor,
-  CSVCancerRelatedMedicationAdministrationExtractor,
-  CSVCancerRelatedMedicationRequestExtractor,
-  CSVClinicalTrialInformationExtractor,
-  CSVConditionExtractor,
-  CSVCTCAdverseEventExtractor,
-  CSVEncounterExtractor,
-  CSVObservationExtractor,
-  CSVPatientExtractor,
-  CSVProcedureExtractor,
-  CSVStagingExtractor,
-  CSVTreatmentPlanChangeExtractor,
-  sortExtractors,
-} = require('mcode-extraction-framework');
+const { CSVExtractors, dependencyInfo, BaseClient, sortExtractors } = require('mcode-extraction-framework');
 const { generateNewMessageBundle } = require('./icareFhirMessaging');
 
 class ICARECSVClient extends BaseClient {
   constructor({ extractors, commonExtractorArgs }) {
     super();
-    this.registerExtractors(
-      CSVAdverseEventExtractor,
-      CSVCancerDiseaseStatusExtractor,
-      CSVCancerRelatedMedicationAdministrationExtractor,
-      CSVCancerRelatedMedicationRequestExtractor,
-      CSVClinicalTrialInformationExtractor,
-      CSVConditionExtractor,
-      CSVCTCAdverseEventExtractor,
-      CSVEncounterExtractor,
-      CSVObservationExtractor,
-      CSVPatientExtractor,
-      CSVProcedureExtractor,
-      CSVStagingExtractor,
-      CSVTreatmentPlanChangeExtractor,
-    );
+    this.registerExtractors(...CSVExtractors);
     // Store the extractors defined by the configuration file as local state
     this.extractorConfig = extractors;
-    // Define information about the order and dependencies of extractors
-    const dependencyInfo = [
-      { type: 'CSVPatientExtractor', dependencies: [] },
-      { type: 'CSVConditionExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVCancerDiseaseStatusExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVClinicalTrialInformationExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVTreatmentPlanChangeExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVStagingExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVCancerRelatedMedicationAdministrationExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVCancerRelatedMedicationRequestExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVProcedureExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVObservationExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVAdverseEventExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVCTCAdverseEventExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVEncounterExtractor', dependencies: ['CSVPatientExtractor'] },
-    ];
     // Sort extractors based on order and dependencies
     this.extractorConfig = sortExtractors(this.extractorConfig, dependencyInfo);
     this.commonExtractorArgs = {

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,7 @@
 const moment = require('moment');
+const fs = require('fs');
+const path = require('path');
+const { AggregateMapper } = require('fhir-mapper');
 const {
   logger,
   sendEmailNotification,
@@ -80,6 +83,19 @@ async function icareApp(
   // Extract the data
   logger.info(`Extracting data for ${patientIds.length} patients`);
   const { extractedData, successfulExtraction, totalExtractionErrors } = await extractDataForPatients(patientIds, icareClient, effectiveFromDate, effectiveToDate);
+
+  // Post-extraction mapping
+  if (fs.existsSync('./config/mapper.js')) {
+    logger.info('Applying post-extraction mapping');
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const { resourceMapping, variables } = require(path.resolve('../../config/mapper.js'));
+    const mapper = new AggregateMapper(resourceMapping, variables);
+    extractedData.map((bundle) => {
+      const mappedBundle = bundle;
+      mappedBundle.entry = mapper.execute(bundle.entry);
+      return bundle;
+    });
+  }
 
   // Post the data using the messagingClient
   let successfulMessagePost = true;


### PR DESCRIPTION
Adds post-extraction mapping [in the same style as the MEF](https://github.com/mcode/mcode-extraction-framework/pull/199) and also now imports list of extractors and extractor dependencies directly from the MEF to make future new extractors easier to pull in. [There is an accompanying PR on the MEF](https://github.com/mcode/mcode-extraction-framework/pull/203)) which will need to be merged in first, but for now, I've modified the `package.json` to point to that branch on the MEF